### PR TITLE
Replace download <button> by <a>

### DIFF
--- a/seahub/templates/shared_file_view.html
+++ b/seahub/templates/shared_file_view.html
@@ -32,7 +32,7 @@
               <button data="{{save_to_link}}" id="save">{% trans "Save to..."%}</button>
               {% endif %}
             {% endif %}
-            <button data="{{ SITE_ROOT }}repo/{{ repo.id }}/{{ obj_id }}/?file_name={{ file_name|urlencode }}&op=download&t={{ shared_token }}&p={{path|urlencode}}" id="download">{% trans "Download" %} ({{file_size|filesizeformat}})</button>
+            <a target="_blank" href="{{ SITE_ROOT }}repo/{{ repo.id }}/{{ obj_id }}/?file_name={{ file_name|urlencode }}&op=download&t={{ shared_token }}&p={{path|urlencode}}" id="download">{% trans "Download" %} ({{file_size|filesizeformat}})</a>
         </div>
         {% include 'snippets/file_content_html.html' %}
     </div>


### PR DESCRIPTION
Hi,

this is a really small thing, but when you set a seafile document/directory as public and share it with a link, people have to click the link then click the "Download" button to actually get the file(s).

What's wrong, in my opinion, is that the "Download" button is not a link. So I can't share it directly with people. As far as I understand, clicking on this button call some javascript, which trigger the download process.

If I'm right, it means search-engines and bots that don't enable javascript can't easily accesss shared documents.

So, I've made this pull request to simply replace the `<button>` tag by an `<a>`.
