### PR TITLE
Fix for if token is valid format, but user with that token does not exist

### DIFF
--- a/seahub/api2/authentication.py
+++ b/seahub/api2/authentication.py
@@ -30,7 +30,10 @@ class TokenAuthentication(BaseAuthentication):
                 token = self.model.objects.get(key=key)
             except self.model.DoesNotExist:
                 return None
-            user = User.objects.get(email=token.user)
+            try:
+                user = User.objects.get(email=token.user)
+            except User.DoesNotExist:
+                return None
             if user.is_active:
                 return (user, token)
 


### PR DESCRIPTION
Many api call will return 500 instead of 403 if token is valid but not associated with a user.  See below for error log that occurs.

2013-12-31 15:05:27,236 [ERROR] django.request:212 handle_uncaught_exception Internal Server Error: /api2/auth/ping/
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/django/core/handlers/base.py", line 115, in get_response
    response = callback(request, _callback_args, *_callback_kwargs)
  File "/usr/lib/python2.7/dist-packages/django/views/generic/base.py", line 68, in view
    return self.dispatch(request, _args, *_kwargs)
  File "/usr/lib/python2.7/dist-packages/django/views/decorators/csrf.py", line 77, in wrapped_view
    return view_func(_args, *_kwargs)
  File "/var/seafile/seafile-pro-server-2.0.5/seahub/thirdpart/rest_framework/views.py", line 363, in dispatch
    response = self.handle_exception(exc)
  File "/var/seafile/seafile-pro-server-2.0.5/seahub/thirdpart/rest_framework/views.py", line 351, in dispatch
    self.initial(request, _args, *_kwargs)
  File "/var/seafile/seafile-pro-server-2.0.5/seahub/thirdpart/rest_framework/views.py", line 287, in initial
    if not self.has_permission(request):
  File "/var/seafile/seafile-pro-server-2.0.5/seahub/thirdpart/rest_framework/views.py", line 254, in has_permission
    if not permission.has_permission(request, self, obj):
  File "/var/seafile/seafile-pro-server-2.0.5/seahub/thirdpart/rest_framework/permissions.py", line 38, in has_permission
    if request.user and request.user.is_authenticated():
  File "/var/seafile/seafile-pro-server-2.0.5/seahub/thirdpart/rest_framework/request.py", line 169, in user
    self._user, self._auth = self._authenticate()
  File "/var/seafile/seafile-pro-server-2.0.5/seahub/thirdpart/rest_framework/request.py", line 289, in _authenticate
    user_auth_tuple = authenticator.authenticate(self)
  File "/var/seafile/seafile-pro-server-2.0.5/seahub/seahub/api2/authentication.py", line 33, in authenticate
    user = User.objects.get(email=token.user)
  File "/var/seafile/seafile-pro-server-2.0.5/seahub/seahub/base/accounts.py", line 65, in get
    raise User.DoesNotExist, 'User matching query does not exits.'
DoesNotExist: User matching query does not exits.
