### PR TITLE
could not connect a nexus7 with valid user and passwd

### DIFF
--- a/seahub/api2/serializers.py
+++ b/seahub/api2/serializers.py
@@ -91,7 +91,7 @@ class AuthTokenSerializer(serializers.Serializer):
         elif platform == 'android':
             # android device id is the 64bit secure id, so it must be 15 or 16 chars in hex representation
             # if hex value starts with 0 device id will be only 15 chars long
-            if (len(device_id) > 16 || len(device_id) < 15):
+            if (len(device_id) > 16 | len(device_id) < 15):
                 raise serializers.ValidationError('invalid device id')
         elif platform == 'ios':
             if len(device_id) != 36:


### PR DESCRIPTION
my nexus 7 device id is only 15 char long.. i guess, the hex encoded value starts with 0 which is not transmitted by default..
