### PR TITLE
share views: Fix missing parameter in copy_file

### DIFF
--- a/seahub/share/views.py
+++ b/seahub/share/views.py
@@ -874,7 +874,7 @@ def save_shared_link(request):
     new_obj_name = check_filename_with_rename(dst_repo_id, dst_path, obj_name)
 
     seafile_api.copy_file(src_repo_id, src_path, obj_name,
-                          dst_repo_id, dst_path, new_obj_name, username)
+                          dst_repo_id, dst_path, new_obj_name, username, False)
 
     messages.success(request, _(u'Successfully saved.'))
 
@@ -966,7 +966,7 @@ def save_private_file_share(request, token):
 
         new_obj_name = check_filename_with_rename(dst_repo_id, dst_path, obj_name)
         seafile_api.copy_file(repo_id, src_path, obj_name,
-                              dst_repo_id, dst_path, new_obj_name, username)
+                              dst_repo_id, dst_path, new_obj_name, username, False)
 
         messages.success(request, _(u'Successfully saved.'))
 


### PR DESCRIPTION
The parameter "need_progress" of copy_file wasn't provided in
save_shared_link and gen_private_file_share
