### PR TITLE
Update german translation (django.po)

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -3988,7 +3988,7 @@ msgstr "%(file_name)s aktualisieren "
 
 #: seahub/templates/repo.html:118
 msgid "Choose a file"
-msgstr "Datei  auswähleen"
+msgstr "Datei  auswählen"
 
 #: seahub/templates/repo.html:122
 #, python-format


### PR DESCRIPTION
Small typo in german translation (auswähleen --> auswählen)
