### PR TITLE
Use the built-in json module

### DIFF
--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -2,7 +2,7 @@
 import logging
 import os
 import stat
-import simplejson as json
+import json
 import datetime
 from urllib2 import unquote, quote
 

--- a/seahub/auth/decorators.py
+++ b/seahub/auth/decorators.py
@@ -7,7 +7,7 @@ from seahub.auth import REDIRECT_FIELD_NAME
 from django.http import HttpResponseRedirect, HttpResponse, Http404
 from django.utils.decorators import available_attrs
 from django.utils.http import urlquote
-import simplejson as json
+import json
 from django.utils.translation import ugettext as _
 
 def user_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_FIELD_NAME):

--- a/seahub/base/models.py
+++ b/seahub/base/models.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-import simplejson as json
+import json
 from django.db import models, IntegrityError
 from django.utils import timezone
 

--- a/seahub/contacts/views.py
+++ b/seahub/contacts/views.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 import logging
-import simplejson as json
+import json
 from django.http import HttpResponse, HttpResponseBadRequest, \
     HttpResponseRedirect
 from django.shortcuts import render_to_response, Http404

--- a/seahub/group/views.py
+++ b/seahub/group/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import os
-import simplejson as json
+import json
 import urllib2
 
 from django.conf import settings

--- a/seahub/message/views.py
+++ b/seahub/message/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import datetime
-import simplejson as json
+import json
 from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.shortcuts import render_to_response
 from django.template.loader import render_to_string

--- a/seahub/notifications/management/commands/send_notices.py
+++ b/seahub/notifications/management/commands/send_notices.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 import datetime
 import logging
-import simplejson as json
+import json
 import os
 import re
 

--- a/seahub/notifications/models.py
+++ b/seahub/notifications/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 import os
-import simplejson as json
+import json
 
 from django.db import models
 from django.db.models.signals import post_save

--- a/seahub/notifications/views.py
+++ b/seahub/notifications/views.py
@@ -1,4 +1,4 @@
-import simplejson as json
+import json
 from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.contrib import messages

--- a/seahub/profile/views.py
+++ b/seahub/profile/views.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 from django.conf import settings
-import simplejson as json
+import json
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.shortcuts import render_to_response

--- a/seahub/share/views.py
+++ b/seahub/share/views.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 import os
 import logging
-import simplejson as json
+import json
 from dateutil.relativedelta import relativedelta
 
 from django.core.urlresolvers import reverse

--- a/seahub/views/__init__.py
+++ b/seahub/views/__init__.py
@@ -2,7 +2,7 @@
 import hashlib
 import os
 import stat
-import simplejson as json
+import json
 import mimetypes
 import urllib2
 import logging

--- a/seahub/views/ajax.py
+++ b/seahub/views/ajax.py
@@ -2,7 +2,7 @@
 import os
 import stat
 import logging
-import simplejson as json
+import json
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse, Http404, HttpResponseBadRequest

--- a/seahub/views/file.py
+++ b/seahub/views/file.py
@@ -6,7 +6,7 @@ view_snapshot_file, view_shared_file, file_edit, etc.
 
 import os
 import hashlib
-import simplejson as json
+import json
 import stat
 import urllib2
 import chardet

--- a/seahub/views/sysadmin.py
+++ b/seahub/views/sysadmin.py
@@ -3,7 +3,7 @@
 import os
 from types import FunctionType
 import logging
-import simplejson as json
+import json
 import re
 import datetime
 import csv, chardet, StringIO

--- a/seahub/views/wiki.py
+++ b/seahub/views/wiki.py
@@ -6,7 +6,7 @@ view_trash_file, view_snapshot_file
 
 import os
 import hashlib
-import simplejson as json
+import json
 import stat
 import tempfile
 import urllib


### PR DESCRIPTION
Python >= 2.6 comes with json by default. simplejson is only useful for Python <= 2.5.

There are still occurrences in `thirdpart/{captcha,rest_framework}` but they use simplejson from `django.utils` which is available in Django 1.5.

Corresponding seafile PR: https://github.com/haiwen/seafile/pull/723
