### PR TITLE
Handled a new parameter called "scope".

### DIFF
--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -169,14 +169,16 @@ class Accounts(APIView):
         # reading scope user list
         scope = request.GET.get('scope', None)
         
-        accounts_ldap = None
-        accounts_db = None
+        accounts_ldap = []
+        accounts_db = []
         if scope:
             scope = scope.upper()
             if scope == 'LDAP':
                 accounts_ldap = seaserv.get_emailusers('LDAP', start, limit)
-            if scope == 'DB':
+            elif scope == 'DB':
                 accounts_db = seaserv.get_emailusers('DB', start, limit)
+            else:
+                return api_error(status.HTTP_400_BAD_REQUEST, "%s is not a valid scope value" % scope)
         else:
             # old way - search first in LDAP if available then DB if no one found
             accounts_ldap = seaserv.get_emailusers('LDAP', start, limit)


### PR DESCRIPTION
If scope is not given than the legacy account search is implemented otherwise if scope is LDAP then the search is only in LDAP user base or DB for local seafile db user base.

The returned JSON list now has also a "source" attribute about user origin.

Maybe also the web API "https://github.com/haiwen/seafile/wiki/Seafile-web-API#check-account-info" should be changed with a "scope" search parameter.

I think that this PR can close, if merged, #256
