### PR TITLE
Changed de msgstr for seahub/templates/shared_link_email.html:12

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -4718,7 +4718,7 @@ msgstr "Hallo,"
 msgid ""
 "%(email)s shared a %(file_shared_type)s <span style=\"font-"
 "weight:bold;\">%(file_shared_name)s</span> to you on %(site_name)s:"
-msgstr "%(email)s hat ein/e %(file_shared_type)s freigeben <span style=\"font-weight:bold;\">%(file_shared_name)s</span> mit Ihnen auf %(site_name)s:"
+msgstr "%(email)s hat die Datei <span style=\"font-weight:bold;\">%(file_shared_name)s</span> (Dateityp: %(file_shared_type)s) für Sie auf %(site_name)s freigegeben."
 
 #: seahub/templates/shared_upload_link_email.html:11
 #, python-format


### PR DESCRIPTION
I just have tested the sharing via email feature and the german translation was a bit clumsy, so I changed it.
