### PR TITLE
Fixed german translation of email body text.

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -4722,7 +4722,7 @@ msgstr "Hallo,"
 msgid ""
 "%(email)s shared a %(file_shared_type)s <span style=\"font-"
 "weight:bold;\">%(file_shared_name)s</span> to you on %(site_name)s:"
-msgstr "%(email)s hat ein/e %(file_shared_type)s freigeben <span style=\"font-weight:bold;\">%(file_shared_name)s</span> mit Ihnen auf %(site_name)s:"
+msgstr "%(email)s hat ein/e %(file_shared_type)s mit dem Namen <span style=\"font-weight:bold;\">%(file_shared_name)s</span> für Sie auf %(site_name)s freigegeben:"
 
 #: seahub/templates/shared_upload_link_email.html:11
 #, python-format


### PR DESCRIPTION
The german body text of the emails sent upon sharing a link to a file/folder sounded very broken. 
For the fix I used the same vocabulary that the rest of the german translation uses.
