### PR TITLE
Update django.po

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -3510,7 +3510,7 @@ msgstr "Verknüpfung erfolgreich aufgehoben."
 #: seahub/templates/snippets/repo_dirents.html:78
 #: seahub/templates/sysadmin/userinfo.html:147
 msgid "Download"
-msgstr "Öffentlich teilen"
+msgstr "Datei herunterlaten"
 
 #: seahub/templates/file_edit.html:84
 #: seahub/templates/repo_history_view.html:38


### PR DESCRIPTION
Wrong german Translation!
"Öffentlich teilen" means "share public". The translation "Datei herunterlaten" would be better.