### PR TITLE
Add more download buttons

### DIFF
--- a/seahub/templates/snippets/my_group_repos.html
+++ b/seahub/templates/snippets/my_group_repos.html
@@ -21,6 +21,7 @@
             <td></td>
           {% endif %}
             <td>
+                <a href="{% url 'repo_download_dir' repo.repo_id %}" class="repo-download-btn op-icon vh" title="{% trans "Download" %}"><img src="{{MEDIA_URL}}img/download.png" alt="" /></a>
               {% if repo.encrypted %}
                 <img src="{{MEDIA_URL}}img/sync-folder-encrypt-20.png" title="{% trans "Read-Write" %}" alt="{% trans "directory icon" %}" />
               {% else %}

--- a/seahub/templates/snippets/my_owned_repos.html
+++ b/seahub/templates/snippets/my_owned_repos.html
@@ -90,9 +90,7 @@
         {% endif %}
         <td data-id="{{ repo.props.id }}" data-name="{{ repo.props.name }}">
             <div>
-                <a href="{% url 'repo_download_dir' repo.props.id %}" class="repo-download-btn op-icon vh" title="{% trans "Download" %}">
-                    <img src="{{MEDIA_URL}}img/download.png" alt="" />
-                </a>
+                <a href="{% url 'repo_download_dir' repo.props.id %}" class="repo-download-btn op-icon vh" title="{% trans "Download" %}"><img src="{{MEDIA_URL}}img/download.png" alt="" /></a>
                 {% if repo.is_original_owner %}
                 <img src="{{MEDIA_URL}}img/share_20.png" alt="" class="repo-share-btn op-icon vh" title="{% trans "Share" %}" />
                 {% endif %}

--- a/seahub/templates/snippets/my_owned_repos.html
+++ b/seahub/templates/snippets/my_owned_repos.html
@@ -46,6 +46,7 @@
         {% endif %}
         <td data-id="{{ repo.props.id }}" data-name="{{ repo.props.name }}">
             <div>
+                <a href="{% url 'repo_download_dir' repo.props.id %}" class="repo-download-btn op-icon vh" title="{% trans "Download" %}"><img src="{{MEDIA_URL}}img/download.png" alt="" /></a>
                 <img src="{{MEDIA_URL}}img/share_20.png" alt="" class="repo-share-btn op-icon vh" title="{% trans "Share" %}" />
                 <img src="{{MEDIA_URL}}img/rm.png" class="repo-delete-btn op-icon vh" title="{% trans "Delete" %}" />
             </div>
@@ -89,6 +90,9 @@
         {% endif %}
         <td data-id="{{ repo.props.id }}" data-name="{{ repo.props.name }}">
             <div>
+                <a href="{% url 'repo_download_dir' repo.props.id %}" class="repo-download-btn op-icon vh" title="{% trans "Download" %}">
+                    <img src="{{MEDIA_URL}}img/download.png" alt="" />
+                </a>
                 {% if repo.is_original_owner %}
                 <img src="{{MEDIA_URL}}img/share_20.png" alt="" class="repo-share-btn op-icon vh" title="{% trans "Share" %}" />
                 {% endif %}

--- a/seahub/templates/snippets/my_shared_repos.html
+++ b/seahub/templates/snippets/my_shared_repos.html
@@ -22,6 +22,7 @@
             {% endif %}
             <td>{{ repo.user|email2nickname }}</td>
             <td>
+                <a href="{% url 'repo_download_dir' repo.repo_id %}" class="repo-download-btn op-icon vh" title="{% trans "Download" %}"><img src="{{MEDIA_URL}}img/download.png" alt="" /></a>
                 {% if show_repo_download_button %}
                 <span data="{{ repo.repo_id }}" class="icon-cloud-download download-btn op-icon vh" title="{% trans "Download and Sync" %}"></span>
                 {% endif %}

--- a/seahub/templates/snippets/repo_dir_data.html
+++ b/seahub/templates/snippets/repo_dir_data.html
@@ -48,6 +48,8 @@
         <button data-url="{% url 'get_shared_link' %}?repo_id={{ repo.id }}&p={{ path|urlencode }}&type=d" data-link="{{ dir_shared_link }}" data-token="{{fileshare.token}}" data-upload-url="{% url 'get_shared_upload_link' %}?repo_id={{ repo.id }}&p={{ path|urlencode }}" data-upload-link="{{ dir_shared_upload_link }}" data-upload-token="{{ uploadlink.token }}" class="op-btn" id="share-cur-dir"><span class="sf-icon-share"></span>{% trans "Share"%}</button>
         {% endif %}
         {% endif %}
+
+        <button onclick="location.href='{% url 'repo_download_dir' repo.id %}?p={{ path|urlencode }}'" class="op-btn"><span class="icon-download"></span>{% trans "Download"%}</button>
     </div>
     <div id="repo-latest-commit" class="clear">
         {% include 'snippets/current_commit.html' %}


### PR DESCRIPTION
As per haiwen/seahub#392. My solution is somewhat hack-ish, so I expect it to be cleaned up before being merged. For example, a button doing `location.href` on click is certainly unacceptable, but that was the only way to achieve what I wanted without modifying CSS. Also, there should probably be an `.icon-download-alt` rule, using an [appropriate download icon](http://fortawesome.github.io/Font-Awesome/icon/download/), and it would probably make more sense to generate download links in controllers, similar to how it's done in `repo_dirents.html`.