### PR TITLE
Shibboleth variable should be configurable. 

### DIFF
--- a/thirdpart/shibboleth/app_settings.py
+++ b/thirdpart/shibboleth/app_settings.py
@@ -11,6 +11,8 @@ SHIB_ATTRIBUTE_MAP = getattr(settings, 'SHIBBOLETH_ATTRIBUTE_MAP', default_shib_
 #Set to true if you are testing and want to insert sample headers.
 SHIB_MOCK_HEADERS = getattr(settings, 'SHIBBOLETH_MOCK_HEADERS', False)
 
+SHIB_USER_HEADER = getattr(settings, 'SHIBBOLETH_USER_HEADER', "REMOTE_USER")
+
 LOGIN_URL = getattr(settings, 'LOGIN_URL', None)
 
 if not LOGIN_URL:

--- a/thirdpart/shibboleth/middleware.py
+++ b/thirdpart/shibboleth/middleware.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.middleware import RemoteUserMiddleware
 from django.core.exceptions import ImproperlyConfigured
 
-from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP, LOGOUT_SESSION_KEY
+from shibboleth.app_settings import SHIB_ATTRIBUTE_MAP, LOGOUT_SESSION_KEY, SHIB_USER_HEADER
 
 from seahub import auth
 from seahub.api2.models import Token
@@ -35,7 +35,7 @@ class ShibbolethRemoteUserMiddleware(RemoteUserMiddleware):
 
         #Locate the remote user header.
         try:
-            username = request.META[self.header]
+            username = request.META[SHIB_USER_HEADER]
         except KeyError:
             # If specified header doesn't exist then return (leaving
             # request.user set to AnonymousUser by the


### PR DESCRIPTION
Environment variable for shibboleth user name should  be configurable. The default is REMOTE_USER which is provided by e.g. apache modules. Using a different variable the value can be changed, e.g. a Domain can be added or replaced or a different field can be used as a primary key. 

This allows to use other authentication modules for Apache, like Kerberos or CAS which don't necessarily provide a username in the right format (xxx@yyy.com). 

Tested using LemonLDAP::NG Single-Sign-On.