### PR TITLE
Redirect using "next" parameter when using shibboleth button

### DIFF
--- a/seahub/templates/registration/login.html
+++ b/seahub/templates/registration/login.html
@@ -133,7 +133,7 @@ $(function() {
 {% if enable_shib_login %}
 $(function() {
     $('#shib-login').click(function() {
-        window.location = "{% url 'shib_login' %}";
+        window.location = "{% url 'shib_login' %}{% if next %}?next={{ next|escape }}{% endif %}";
         return false;
     });
 });

--- a/seahub/views/__init__.py
+++ b/seahub/views/__init__.py
@@ -2004,4 +2004,4 @@ def image_view(request, filename):
     return response
 
 def shib_login(request):
-    return HttpResponseRedirect(reverse('myhome'))
+    return HttpResponseRedirect(request.GET.get("next",reverse('myhome')))


### PR DESCRIPTION
Use the next parameter for shibboleth, just like for the normal login button.