### PR TITLE
Bugfix creating a public share set_inner_pub_repo does not exist in Seaf...

### DIFF
--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -2545,7 +2545,7 @@ class SharedRepo(APIView):
         elif share_type == 'public':
             if not CLOUD_MODE:
                 try:
-                    seafile_api.set_inner_pub_repo(repo_id, permission)
+                    seafile_api.add_inner_pub_repo(repo_id, permission)
                 except SearpcError, e:
                     return api_error(status.HTTP_500_INTERNAL_SERVER_ERROR,
                                      "Searpc Error: " + e.msg)


### PR DESCRIPTION
...ileAPI

Previously the Web API call to share a library as public would give an error in the log and fail. Renaming the call from set_inner_pub_repo to add_inner_pub_repo works perfectly