### PR TITLE
change file-sorting interaction

### DIFF
--- a/seahub/templates/js/templates.html
+++ b/seahub/templates/js/templates.html
@@ -173,10 +173,10 @@
         </th>
         <th class="star"></th>
         <th class="dirent-icon"></th>
-        <th><span class="dirent-name">{% trans "Name"%} <span id="by-name" class="icon-caret-up cspt"></span></span></th>
+        <th class="by-name cspt"><span class="dirent-name">{% trans "Name"%} <span class="sort-icon icon-caret-up"></span></span></th>
         <th class="dirent-op"></th>
         <th class="dirent-size">{% trans "Size"%}</th>
-        <th class="dirent-update">{% trans "Last Update" %} <span id="by-time" class="icon-caret-down cspt"></span></th>
+        <th class="dirent-update by-time cspt">{% trans "Last Update" %} <span class="sort-icon icon-caret-down hide"></span></th>
     </tr>
 </script>
 <script type="text/template" id="dirent-tmpl">
@@ -719,19 +719,19 @@
 <script type="text/template" id="my-repos-hd-tmpl">
    <tr>
        <th width="4%"><!--icon--></th>
-       <th width="46%">{% trans "Name" %} <span class="by-name icon-caret-up cspt"></span></th>
+       <th class="by-name cspt" width="46%">{% trans "Name" %} <span class="sort-icon icon-caret-down hide"></span></th>
        <th width="10%"><!--op--></th>
        <th width="20%">{% trans "Size" %}</th>
-       <th width="20%">{% trans "Last Update" %} <span class="by-time icon-caret-down cspt"></span></th>
+       <th class="by-time cspt" width="20%">{% trans "Last Update" %} <span class="sort-icon icon-caret-up"></span></th>
    </tr>
 </script>
 <script type="text/template" id="shared-repos-hd-tmpl">
     <tr>
         <th width="4%"><!--icon--></th>
-        <th width="40%">{% trans "Name" %} <span class="by-name icon-caret-up cspt"></span></th>
+        <th class="by-name cspt" width="40%">{% trans "Name" %} <span class="sort-icon icon-caret-down hide"></span></th>
         <th width="8%"><!--op--></th>
         <th width="14%">{% trans "Size" %}</th>
-        <th width="18%">{% trans "Last Update" %} <span class="by-time icon-caret-down cspt"></span></th>
+        <th class="by-time cspt"  width="18%">{% trans "Last Update" %} <span class="sort-icon icon-caret-up"></span></th>
         <th width="16%">{% trans "Shared By" %}</th>
     </tr>
 </script>

--- a/static/scripts/app/views/dir.js
+++ b/static/scripts/app/views/dir.js
@@ -293,8 +293,8 @@ define([
                 'click #mv-dirents': 'mv',
                 'click #cp-dirents': 'cp',
                 'click #del-dirents': 'del',
-                'click #by-name': 'sortByName',
-                'click #by-time': 'sortByTime'
+                'click .by-name': 'sortByName',
+                'click .by-time': 'sortByTime'
             },
 
             newDir: function() {
@@ -450,8 +450,9 @@ define([
             },
 
             sortByName: function() {
+                $('.by-time .sort-icon').hide();
                 var dirents = this.dir;
-                var el = $('#by-name');
+                var el = $('.by-name .sort-icon');
 
                 dirents.comparator = function(a, b) {
                     if (a.get('is_dir') && b.get('is_file')) {
@@ -467,17 +468,17 @@ define([
                         return result;
                     }
                 };
-
                 dirents.sort();
                 this.$dirent_list.empty();
                 dirents.each(this.addOne, this);
-                el.toggleClass('icon-caret-up icon-caret-down');
+                el.toggleClass('icon-caret-up icon-caret-down').show();
                 dirents.comparator = null;
             },
 
             sortByTime: function () {
+                $('.by-name .sort-icon').hide();
                 var dirents = this.dir;
-                var el = $('#by-time');
+                var el = $('.by-time .sort-icon');
                 dirents.comparator = function(a, b) {
                     if (a.get('is_dir') && b.get('is_file')) {
                         return -1;
@@ -491,7 +492,7 @@ define([
                 dirents.sort();
                 this.$dirent_list.empty();
                 dirents.each(this.addOne, this);
-                el.toggleClass('icon-caret-up icon-caret-down');
+                el.toggleClass('icon-caret-up icon-caret-down').show();
                 dirents.comparator = null;
             },
 

--- a/static/scripts/app/views/group.js
+++ b/static/scripts/app/views/group.js
@@ -18,8 +18,8 @@ define([
 
         events: {
             'click .repo-create': 'createRepo',
-            'click #grp-repos .by-name': 'sortByName',
-            'click #grp-repos .by-time': 'sortByTime'
+            'click .by-name': 'sortByName',
+            'click .by-time': 'sortByTime'
         },
 
         initialize: function(options) {
@@ -131,8 +131,9 @@ define([
         },
 
         sortByName: function() {
+            $('.by-time .sort-icon').hide();
             var repos = this.repos;
-            var el = $('.by-name', this.$table);
+            var el = $('.by-name .sort-icon', this.$table);
             repos.comparator = function(a, b) { // a, b: model
                 var result = Common.compareTwoWord(a.get('name'), b.get('name'));
                 if (el.hasClass('icon-caret-up')) {
@@ -144,14 +145,15 @@ define([
             repos.sort();
             this.$tableBody.empty();
             repos.each(this.addOne, this);
-            el.toggleClass('icon-caret-up icon-caret-down');
+            el.toggleClass('icon-caret-up icon-caret-down').show();
             repos.comparator = null;
 
         },
 
         sortByTime: function() {
+            $('.by-name .sort-icon').hide();
             var repos = this.repos;
-            var el = $('.by-time', this.$table);
+            var el = $('.by-time .sort-icon', this.$table);
             repos.comparator = function(a, b) { // a, b: model
                 if (el.hasClass('icon-caret-down')) {
                     return a.get('mtime') < b.get('mtime') ? 1 : -1;
@@ -162,7 +164,7 @@ define([
             repos.sort();
             this.$tableBody.empty();
             repos.each(this.addOne, this);
-            el.toggleClass('icon-caret-up icon-caret-down');
+            el.toggleClass('icon-caret-up icon-caret-down').show();
             repos.comparator = null;
         },
 

--- a/static/scripts/app/views/myhome-repos.js
+++ b/static/scripts/app/views/myhome-repos.js
@@ -114,8 +114,9 @@ define([
         },
 
         sortByName: function() {
+            $('.by-time .sort-icon').hide();
             var repos = this.repos;
-            var el = $('.by-name', this.$table);
+            var el = $('.by-name .sort-icon', this.$table);
             repos.comparator = function(a, b) { // a, b: model
                 var result = Common.compareTwoWord(a.get('name'), b.get('name'));
                 if (el.hasClass('icon-caret-up')) {
@@ -127,13 +128,14 @@ define([
             repos.sort();
             this.$tableBody.empty();
             repos.each(this.addOne, this);
-            el.toggleClass('icon-caret-up icon-caret-down');
+            el.toggleClass('icon-caret-up icon-caret-down').show();
             repos.comparator = null;
         },
 
         sortByTime: function() {
+            $('.by-name .sort-icon').hide();
             var repos = this.repos;
-            var el = $('.by-time', this.$table);
+            var el = $('.by-time .sort-icon', this.$table);
             repos.comparator = function(a, b) { // a, b: model
                 if (el.hasClass('icon-caret-down')) {
                     return a.get('mtime') < b.get('mtime') ? 1 : -1;
@@ -144,7 +146,7 @@ define([
             repos.sort();
             this.$tableBody.empty();
             repos.each(this.addOne, this);
-            el.toggleClass('icon-caret-up icon-caret-down');
+            el.toggleClass('icon-caret-up icon-caret-down').show();
             repos.comparator = null;
         }
 

--- a/static/scripts/app/views/organization.js
+++ b/static/scripts/app/views/organization.js
@@ -139,8 +139,9 @@ define([
         },
 
         sortByName: function() {
+            $('.by-time .sort-icon').hide();
             var repos = this.repos;
-            var el = $('.by-name', this.$table);
+            var el = $('.by-name .sort-icon', this.$table);
             repos.comparator = function(a, b) { // a, b: model
                 var result = Common.compareTwoWord(a.get('name'), b.get('name'));
                 if (el.hasClass('icon-caret-up')) {
@@ -152,13 +153,14 @@ define([
             repos.sort();
             this.$tableBody.empty();
             repos.each(this.addOne, this);
-            el.toggleClass('icon-caret-up icon-caret-down');
+            el.toggleClass('icon-caret-up icon-caret-down').show();
             repos.comparator = null;
         },
 
         sortByTime: function() {
+            $('.by-name .sort-icon').hide();
             var repos = this.repos;
-            var el = $('.by-time', this.$table);
+            var el = $('.by-time .sort-icon', this.$table);
             repos.comparator = function(a, b) { // a, b: model
                 if (el.hasClass('icon-caret-down')) {
                     return a.get('mtime') < b.get('mtime') ? 1 : -1;
@@ -169,7 +171,7 @@ define([
             repos.sort();
             this.$tableBody.empty();
             repos.each(this.addOne, this);
-            el.toggleClass('icon-caret-up icon-caret-down');
+            el.toggleClass('icon-caret-up icon-caret-down').show();
             repos.comparator = null;
         },
 


### PR DESCRIPTION
At first, all the files are sorted by time.
![e1](https://cloud.githubusercontent.com/assets/8553587/8542908/c02299fc-24cb-11e5-9071-f5d253987e09.png)
When the mouse sweeps, the mouse pointer becomes a 'hand'.
Click it, then all the files are sorted by name, just like this,
![e2](https://cloud.githubusercontent.com/assets/8553587/8543021/849ab544-24cc-11e5-8d52-6147ab222589.png)
Only one arrow shows for the corresponding method.