### PR TITLE
values from request.POST.get are already unquoted

### DIFF
--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -1441,7 +1441,7 @@ class OpDeleteView(APIView):
 
         parent_dir_utf8 = parent_dir.encode('utf-8')
         for file_name in file_names.split(':'):
-            file_name = unquote(file_name.encode('utf-8'))
+            file_name = file_name.encode('utf-8')
             try:
                 seafile_api.del_file(repo_id, parent_dir_utf8,
                                      file_name, username)
@@ -1486,7 +1486,7 @@ class OpMoveView(APIView):
 
         parent_dir_utf8 = parent_dir.encode('utf-8')
         for file_name in file_names.split(':'):
-            file_name = unquote(file_name.encode('utf-8'))
+            file_name = file_name.encode('utf-8')
             new_filename = check_filename_with_rename_utf8(dst_repo, dst_dir,
                                                            file_name)
             try:
@@ -1538,7 +1538,7 @@ class OpCopyView(APIView):
 
         parent_dir_utf8 = parent_dir.encode('utf-8')
         for file_name in file_names.split(':'):
-            file_name = unquote(file_name.encode('utf-8'))
+            file_name = file_name.encode('utf-8')
             new_filename = check_filename_with_rename_utf8(dst_repo, dst_dir,
                                                            file_name)
             try:
@@ -1573,7 +1573,7 @@ class StarredFileView(APIView):
     def post(self, request, format=None):
         # add starred file
         repo_id = request.POST.get('repo_id', '')
-        path = unquote(request.POST.get('p', '').encode('utf-8'))
+        path = request.POST.get('p', '').encode('utf-8')
         if not (repo_id and path):
             return api_error(status.HTTP_400_BAD_REQUEST,
                              'Repo_id or path is missing.')
@@ -1679,7 +1679,7 @@ class FileView(APIView):
             if not newname:
                 return api_error(status.HTTP_400_BAD_REQUEST,
                                  'Newname is missing')
-            newname = unquote(newname.encode('utf-8'))
+            newname = newname.encode('utf-8')
             if len(newname) > settings.MAX_UPLOAD_FILE_NAME_LEN:
                 return api_error(status.HTTP_400_BAD_REQUEST, 'Newname too long')
 

--- a/tests/api/test_starredfiles.py
+++ b/tests/api/test_starredfiles.py
@@ -9,6 +9,7 @@ from seahub.test_utils import BaseTestCase, Fixtures
 
 
 class StarredFileTest(BaseTestCase, Fixtures):
+    unicode_name = 'März_中文_%2F_FG2_SW#1a.jpg'
     def setUp(self):
         UserStarredFiles(email=self.user.username, org_id=-1,
                          repo_id=self.repo.id, path=self.file,
@@ -16,9 +17,6 @@ class StarredFileTest(BaseTestCase, Fixtures):
 
     def tearDown(self):
         self.remove_repo()
-
-    def js_encodeURIComponent(self, string):
-        return urllib2.quote(string.encode('utf-8'), safe='~()*!.\'')
 
     def test_can_list(self):
         self.login_as(self.user)
@@ -51,7 +49,7 @@ class StarredFileTest(BaseTestCase, Fixtures):
 
         resp = self.client.post(reverse('starredfiles'), {
             'repo_id': self.repo.id,
-            'p': self.js_encodeURIComponent(u'März_中文_%2F_FG2_SW#1a.jpg'),
+            'p': self.unicode_name,
         })
         self.assertEqual(201, resp.status_code)
         self.assertEqual('"success"', resp.content)
@@ -62,13 +60,13 @@ class StarredFileTest(BaseTestCase, Fixtures):
 
         resp = self.client.post(reverse('starredfiles'), {
             'repo_id': self.repo.id,
-            'p': self.js_encodeURIComponent(u'März_中文_%2F_FG2_SW#1a.jpg')
+            'p': self.unicode_name,
         })
         self.assertEqual(201, resp.status_code)
         self.assertEqual(2, len(UserStarredFiles.objects.all()))
 
         resp = self.client.delete(reverse('starredfiles') + '?repo_id=' +
                                   self.repo.id + '&p=' +
-                                  self.js_encodeURIComponent(u'März_中文_%2F_FG2_SW#1a.jpg'))
+                                  urllib2.quote(self.unicode_name))
         self.assertEqual(200, resp.status_code)
         self.assertEqual(1, len(UserStarredFiles.objects.all()))


### PR DESCRIPTION
Otherwise the name `%2F.txt` would be treated as `/.txt` incorrectly.
