### PR TITLE
Fixing syntax error in secret_key_generator

### DIFF
--- a/tools/secret_key_generator.py
+++ b/tools/secret_key_generator.py
@@ -50,4 +50,4 @@ if __name__ == "__main__":
         fp.write("SECRET_KEY = \"%s\"\n" % key)
         fp.close()
     else:
-        print key
+        print(key)


### PR DESCRIPTION
Ran into this one while upgrading from 4.3 to 4.4 on a raspbarry pi.