### PR TITLE
Make user search case insensitive

### DIFF
--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -313,12 +313,12 @@ class SearchUser(APIView):
 
                 searched_users = filter(lambda u: q in u.email, users)
                 # 'user__in' for only get profile of user in org
-                # 'nickname__contains' for search by nickname
+                # 'nickname__icontains' for search by nickname
                 searched_profiles = Profile.objects.filter(Q(user__in=[u.email for u in users]) & \
-                                                           Q(nickname__contains=q)).values('user')
+                                                           Q(nickname__icontains=q)).values('user')
             elif ENABLE_GLOBAL_ADDRESSBOOK:
                 searched_users = get_searched_users(q)
-                searched_profiles = Profile.objects.filter(nickname__contains=q).values('user')
+                searched_profiles = Profile.objects.filter(nickname__icontains=q).values('user')
             else:
                 users = []
                 contacts = Contact.objects.get_contacts_by_user(username)
@@ -334,12 +334,12 @@ class SearchUser(APIView):
 
                 searched_users = filter(lambda u: q in u.email, users)
                 # 'user__in' for only get profile of contacts
-                # 'nickname__contains' for search by nickname
+                # 'nickname__icontains' for search by nickname
                 searched_profiles = Profile.objects.filter(Q(user__in=[u.email for u in users]) & \
-                                                           Q(nickname__contains=q)).values('user')
+                                                           Q(nickname__icontains=q)).values('user')
         else:
             searched_users = get_searched_users(q)
-            searched_profiles = Profile.objects.filter(nickname__contains=q).values('user')
+            searched_profiles = Profile.objects.filter(nickname__icontains=q).values('user')
 
 
         # remove inactive users and add to result

--- a/tests/api/test_search_user.py
+++ b/tests/api/test_search_user.py
@@ -5,6 +5,7 @@ from django.core.urlresolvers import reverse
 from seahub.profile.models import Profile
 from seahub.test_utils import BaseTestCase
 
+
 class SearchUserTest(BaseTestCase):
     def setUp(self):
         self.login_as(self.user)
@@ -24,4 +25,36 @@ class SearchUserTest(BaseTestCase):
         assert json_resp['users'][0]['avatar'] is not None
         assert json_resp['users'][0]['avatar_url'] is not None
         assert json_resp['users'][0]['name'] == 'test'
+        assert json_resp['users'][0]['contact_email'] == 'new_mail@test.com'
+
+    def test_can_search_by_nickname(self):
+        p = Profile.objects.add_or_update(self.user.email, nickname="Test")
+        p.contact_email = 'new_mail@test.com'
+        p.save()
+
+        resp = self.client.get(self.endpoint + '?q=' + "Test")
+        json_resp = json.loads(resp.content)
+
+        self.assertEqual(200, resp.status_code)
+        assert json_resp['users'] is not None
+        assert json_resp['users'][0]['email'] == self.user.email
+        assert json_resp['users'][0]['avatar'] is not None
+        assert json_resp['users'][0]['avatar_url'] is not None
+        assert json_resp['users'][0]['name'] == 'Test'
+        assert json_resp['users'][0]['contact_email'] == 'new_mail@test.com'
+
+    def test_can_search_by_nickname_insensitive(self):
+        p = Profile.objects.add_or_update(self.user.email, nickname="Test")
+        p.contact_email = 'new_mail@test.com'
+        p.save()
+
+        resp = self.client.get(self.endpoint + '?q=' + "test")
+        json_resp = json.loads(resp.content)
+
+        self.assertEqual(200, resp.status_code)
+        assert json_resp['users'] is not None
+        assert json_resp['users'][0]['email'] == self.user.email
+        assert json_resp['users'][0]['avatar'] is not None
+        assert json_resp['users'][0]['avatar_url'] is not None
+        assert json_resp['users'][0]['name'] == 'Test'
         assert json_resp['users'][0]['contact_email'] == 'new_mail@test.com'

--- a/tests/api/test_search_user.py
+++ b/tests/api/test_search_user.py
@@ -28,11 +28,11 @@ class SearchUserTest(BaseTestCase):
         assert json_resp['users'][0]['contact_email'] == 'new_mail@test.com'
 
     def test_can_search_by_nickname(self):
-        p = Profile.objects.add_or_update(self.user.email, nickname="Test")
+        p = Profile.objects.add_or_update(self.user.email, nickname="Carl Smith")
         p.contact_email = 'new_mail@test.com'
         p.save()
 
-        resp = self.client.get(self.endpoint + '?q=' + "Test")
+        resp = self.client.get(self.endpoint + '?q=' + "Carl")
         json_resp = json.loads(resp.content)
 
         self.assertEqual(200, resp.status_code)
@@ -40,15 +40,15 @@ class SearchUserTest(BaseTestCase):
         assert json_resp['users'][0]['email'] == self.user.email
         assert json_resp['users'][0]['avatar'] is not None
         assert json_resp['users'][0]['avatar_url'] is not None
-        assert json_resp['users'][0]['name'] == 'Test'
+        assert json_resp['users'][0]['name'] == 'Carl Smith'
         assert json_resp['users'][0]['contact_email'] == 'new_mail@test.com'
 
     def test_can_search_by_nickname_insensitive(self):
-        p = Profile.objects.add_or_update(self.user.email, nickname="Test")
+        p = Profile.objects.add_or_update(self.user.email, nickname="Carl Smith")
         p.contact_email = 'new_mail@test.com'
         p.save()
 
-        resp = self.client.get(self.endpoint + '?q=' + "test")
+        resp = self.client.get(self.endpoint + '?q=' + "carl")
         json_resp = json.loads(resp.content)
 
         self.assertEqual(200, resp.status_code)
@@ -56,5 +56,5 @@ class SearchUserTest(BaseTestCase):
         assert json_resp['users'][0]['email'] == self.user.email
         assert json_resp['users'][0]['avatar'] is not None
         assert json_resp['users'][0]['avatar_url'] is not None
-        assert json_resp['users'][0]['name'] == 'Test'
+        assert json_resp['users'][0]['name'] == 'Carl Smith'
         assert json_resp['users'][0]['contact_email'] == 'new_mail@test.com'


### PR DESCRIPTION
If you want to find "Carl Smith", typing "carl" should list him, too.
People are lazy and expect case insensitive searches.
They don't think "Oh. I have to type 'Carl' instead.". They think
"Search doesn't work.".