### PR TITLE
Fix for ampersand in file path of download link

### DIFF
--- a/seahub/templates/shared_file_view.html
+++ b/seahub/templates/shared_file_view.html
@@ -38,7 +38,7 @@
               {% endif %}
             {% endif %}
             {% if not traffic_over_limit %}
-              <a href="{% if from_shared_dir %}?p={{path}}&dl=1{% else %}?dl=1{% endif %}" class="obv-btn">{% trans "Download" %} ({{file_size|filesizeformat}})</a>
+              <a href="{% if from_shared_dir %}?p={{path|urlencode}}&dl=1{% else %}?dl=1{% endif %}" class="obv-btn">{% trans "Download" %} ({{file_size|filesizeformat}})</a>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
Without this, the big green download link will not work when there is an ampersand in the file path.