### PR TITLE
remove urlquote when reverse

### DIFF
--- a/seahub/notifications/management/commands/send_notices.py
+++ b/seahub/notifications/management/commands/send_notices.py
@@ -137,8 +137,8 @@ class Command(BaseCommand):
         repo_id = d['repo_id']
         uploaded_to = d['uploaded_to'].rstrip('/')
         file_path = uploaded_to + '/' + file_name
-        file_link = reverse('view_lib_file', args=[repo_id, urlquote(file_path)])
-        folder_link = reverse('view_common_lib_dir', args=[repo_id, urlquote(uploaded_to).strip('/')])
+        file_link = reverse('view_lib_file', args=[repo_id, file_path])
+        folder_link = reverse('view_common_lib_dir', args=[repo_id, uploaded_to.strip('/')])
         folder_name = os.path.basename(uploaded_to)
 
         notice.file_link = file_link

--- a/seahub/notifications/models.py
+++ b/seahub/notifications/models.py
@@ -524,10 +524,10 @@ class UserNotification(models.Model):
             else:
                 uploaded_to = d['uploaded_to'].rstrip('/')
                 file_path = uploaded_to + '/' + filename
-                link = reverse('view_common_lib_dir', args=[repo_id, urlquote(uploaded_to.lstrip('/'))])
+                link = reverse('view_common_lib_dir', args=[repo_id, uploaded_to.lstrip('/')])
                 name = os.path.basename(uploaded_to)
 
-            file_link = reverse('view_lib_file', args=[repo_id, urlquote(file_path)])
+            file_link = reverse('view_lib_file', args=[repo_id, file_path])
 
             msg = _(u"A file named <a href='%(file_link)s'>%(file_name)s</a> is uploaded to <a href='%(link)s'>%(name)s</a>") % {
                 'file_link': file_link,

--- a/seahub/views/__init__.py
+++ b/seahub/views/__init__.py
@@ -249,7 +249,7 @@ def get_repo_dirents(request, repo, commit, path, offset=-1, limit=-1):
                 dirent.starred = False
                 fpath = posixpath.join(path, dirent.obj_name)
                 p_fpath = posixpath.join(path, dirent.obj_name)
-                dirent.view_link = reverse('view_lib_file', args=[repo.id, urlquote(p_fpath)])
+                dirent.view_link = reverse('view_lib_file', args=[repo.id, p_fpath])
                 dirent.dl_link = get_file_download_link(repo.id, dirent.obj_id,
                                                         p_fpath)
                 dirent.history_link = file_history_base + '?p=' + urlquote(p_fpath)
@@ -1339,13 +1339,13 @@ def convert_cmmt_desc_link(request):
 
         if d.status == 'add' or d.status == 'mod':  # Add or modify file
             return HttpResponseRedirect(
-                reverse('view_lib_file', args=[repo_id, '/' + urlquote(d.name)]))
+                reverse('view_lib_file', args=[repo_id, '/' + d.name]))
         elif d.status == 'mov':  # Move or Rename file
             return HttpResponseRedirect(
-                reverse('view_lib_file', args=[repo_id, '/' + urlquote(d.new_name)]))
+                reverse('view_lib_file', args=[repo_id, '/' + d.new_name]))
         elif d.status == 'newdir':
             return HttpResponseRedirect(
-                reverse('view_common_lib_dir', args=[repo_id, urlquote(d.name).strip('/')]))
+                reverse('view_common_lib_dir', args=[repo_id, d.name.strip('/')]))
         else:
             continue
 

--- a/seahub/views/ajax.py
+++ b/seahub/views/ajax.py
@@ -945,7 +945,7 @@ def mv_dirents(request, src_repo_id, src_path, dst_repo_id, dst_path,
             success.append(obj_name)
 
     if len(success) > 0:
-        url = reverse("view_common_lib_dir", args=[dst_repo_id, urlquote(dst_path).strip('/')])
+        url = reverse("view_common_lib_dir", args=[dst_repo_id, dst_path.strip('/')])
 
     result = {'success': success, 'failed': failed, 'url': url}
     return HttpResponse(json.dumps(result), content_type=content_type)
@@ -988,7 +988,7 @@ def cp_dirents(request, src_repo_id, src_path, dst_repo_id, dst_path, obj_file_n
             success.append(obj_name)
 
     if len(success) > 0:
-        url = reverse("view_common_lib_dir", args=[dst_repo_id, urlquote(dst_path).strip('/')])
+        url = reverse("view_common_lib_dir", args=[dst_repo_id, dst_path.strip('/')])
 
     result = {'success': success, 'failed': failed, 'url': url}
     return HttpResponse(json.dumps(result), content_type=content_type)

--- a/seahub/views/file.py
+++ b/seahub/views/file.py
@@ -253,7 +253,7 @@ def convert_md_link(file_content, repo_id, username):
             try:
                 dirent = get_wiki_dirent(repo_id, link_name)
                 path = "/" + dirent.obj_name
-                href = reverse('view_lib_file', args=[repo_id, urlquote(path)])
+                href = reverse('view_lib_file', args=[repo_id, path])
                 a_tag = '''<a href="%s">%s</a>'''
                 return a_tag % (href, link_alias)
             except (WikiDoesNotExist, WikiPageMissing):
@@ -276,7 +276,7 @@ def convert_md_link(file_content, repo_id, username):
             # convert other types of filelinks to clickable links
             path = "/" + link_name
             icon = file_icon_filter(link_name)
-            s = reverse('view_lib_file', args=[repo_id, urlquote(path)])
+            s = reverse('view_lib_file', args=[repo_id, path])
             a_tag = '''<img src="%simg/file/%s" alt="%s" class="vam" /> <a href="%s" target="_blank" class="vam">%s</a>'''
             return a_tag % (MEDIA_URL, icon, icon, s, link_name)
 
@@ -1102,7 +1102,7 @@ def file_edit_submit(request, repo_id):
         wiki_name = os.path.splitext(os.path.basename(path))[0]
         next = reverse('personal_wiki', args=[wiki_name])
     else:
-        next = reverse('view_lib_file', args=[repo_id, urlquote(path)])
+        next = reverse('view_lib_file', args=[repo_id, path])
 
     parent_dir = os.path.dirname(path).encode('utf-8')
     filename = os.path.basename(path).encode('utf-8')
@@ -1172,7 +1172,7 @@ def file_edit(request, repo_id):
 
     # Redirect to different place according to from page when user click
     # cancel button on file edit page.
-    cancel_url = reverse('view_lib_file', args=[repo.id, urlquote(path)])
+    cancel_url = reverse('view_lib_file', args=[repo.id, path])
     page_from = request.GET.get('from', '')
     gid = request.GET.get('gid', '')
     wiki_name = os.path.splitext(u_filename)[0]

--- a/seahub/wiki/utils.py
+++ b/seahub/wiki/utils.py
@@ -162,7 +162,7 @@ def convert_wiki_link(content, url_prefix, repo_id, username):
             # convert other types of filelinks to clickable links
             path = "/" + page_name
             icon = file_icon_filter(page_name)
-            s = reverse('view_lib_file', args=[repo_id, urlquote(path)])
+            s = reverse('view_lib_file', args=[repo_id, path])
             a_tag = '''<img src="%simg/file/%s" alt="%s" class="file-icon vam" /> <a href="%s" class="vam" target="_blank">%s</a>'''
             ret = a_tag % (settings.MEDIA_URL, icon, icon, smart_str(s), page_name)
             return smart_str(ret)

--- a/tests/seahub/share/views/test_list_priv_shared_folders.py
+++ b/tests/seahub/share/views/test_list_priv_shared_folders.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
 
-from django.utils.http import urlquote
 from django.core.urlresolvers import reverse
 
 from seaserv import seafile_api
@@ -16,7 +15,7 @@ class ListPrivSharedFoldersTest(BaseTestCase):
         username = self.user.username
 
         parent_dir = '/'
-        dirname = '<img onerror=alert(1) src=a>_"_Ω_%2F_W_#_12_这'
+        dirname = 'test-folder'
         full_dir_path = os.path.join(parent_dir, dirname)
 
         # create folder
@@ -31,5 +30,5 @@ class ListPrivSharedFoldersTest(BaseTestCase):
         self.login_as(self.user)
         resp = self.client.get(reverse('list_priv_shared_folders'))
         self.assertEqual(200, resp.status_code)
-        href = reverse("view_common_lib_dir", args=[repo_id, urlquote(full_dir_path).strip('/')])
+        href = reverse("view_common_lib_dir", args=[repo_id, full_dir_path.strip('/')])
         self.assertRegexpMatches(resp.content, href)


### PR DESCRIPTION
When reversing URLs, Django didn't apply urlquote() to arguments before interpolating them in URL patterns. This bug is fixed in Django 1.6. If you worked around this bug by applying URL quoting before passing arguments to reverse(), this may result in double-quoting. If this happens, simply remove the URL quoting from your code.