### PR TITLE
Add instructions for how to set up in a virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ docs/_build/*
 deps
 ghostdriver.log
 seahub/thumbnail/thumb/*
+.virtualenv

--- a/README.markdown
+++ b/README.markdown
@@ -17,9 +17,14 @@ You can grab souce code from GitHub.
 
     $ git clone git://github.com/haiwen/seahub.git
 
+Set up a virtualenv to install dependencies locally:
+
+    $ virtualenv .virtualenv
+    $ . .virtualenv/bin/activate
+
 Install python libraries by pip:
 
-    pip install -r requirements.txt
+    $ pip install -r requirements.txt
 
 
 Configuration
@@ -38,7 +43,8 @@ Run and Verify
 
 Run as:
 
-    ./run-seahub.sh.template
+    $ . .virtualenv/bin/activate
+    $ ./run-seahub.sh.template
 
 Then open your browser, and input `http://localhost:8000/`, there should be a Login page. You can create admin account using `seahub-admin.py` script under `tools/` directory.
 


### PR DESCRIPTION
Using a virtualenv is much better than globally installing all of the
project's dependencies, as it doesn't pollute the global package space,
and allows us to work just within the project folder.