### PR TITLE
[onlyoffice] Fix document key

### DIFF
--- a/seahub/views/file.py
+++ b/seahub/views/file.py
@@ -455,7 +455,7 @@ def _file_view(request, repo_id, path):
 
     if ENABLE_ONLYOFFICE and not repo.encrypted and \
        fileext in ONLYOFFICE_FILE_EXTENSION:
-        doc_key = gen_token(10)
+        doc_key = obj_id
         if fileext in ('xls', 'xlsx', 'ods', 'fods', 'csv'):
             document_type = 'spreadsheet'
         elif fileext in ('pptx', 'ppt', 'odp', 'fodp', 'ppsx', 'pps'):


### PR DESCRIPTION
According to https://api.onlyoffice.com/editors/config/document, the key
should be changed when document is edited *and* saved. Using a different
key each time the document is opened tells document server a different version
of the file is edited and thus breaks save operations as well as collaborative
editing.

Use obj_id as key since it's a file content based uuid.