### PR TITLE
Add "View Snapshot" ref to file revision page

### DIFF
--- a/seahub/templates/file_revisions.html
+++ b/seahub/templates/file_revisions.html
@@ -88,6 +88,9 @@
                     {% if can_compare and not forloop.last %}
                     <a href="{% url 'text_diff' repo.id %}?p={{commit.path|urlencode}}&commit={{commit.id}}" class="op vh text-diff">{% trans 'Diff' %}</a>
                     {% endif %}
+                    {% if user_perm == 'rw' and not commit.is_first_commit %}
+                    <a href="{% url 'repo_history_view' repo.id %}?commit_id={{ commit.id }}" class="op vh view-snapshot">{% trans "View Snapshot" %}</a>
+                    {% endif %}
                 </td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
I think this should work, but I didn't test it. I mostly copied this from [seahub/seahub/templates/repo_history.html#L86-L92](https://github.com/haiwen/seahub/blob/75db0b68759dc184aebeaeae1280e78d3984637d/seahub/templates/repo_history.html#L86-L92)

https://forum.seafile.com/t/add-view-snapshot-button-on-file-history-page/3758