### PR TITLE
remove image width and height attributes of custom logo in javascript

### DIFF
--- a/seahub/templates/registration/login.html
+++ b/seahub/templates/registration/login.html
@@ -89,7 +89,7 @@ html, body, #wrapper { height:100%; }
 
 {% block extra_script %}
 <script type="text/javascript">
-$('.login-panel-outer-container').prepend($($('#logo').html()).attr({'width': 160, 'height':40}).addClass('login-panel-logo'));
+$('.login-panel-outer-container').prepend($($('#logo').html()).addClass('login-panel-logo'));
 $('.login-panel-bottom-container').append($('#lang').removeClass('fright'));
 
 var $el = $('.login-panel-outer-container');


### PR DESCRIPTION
if you have a custom logo setup, the width and height of that image gets overwritten in the loginform
this fix removes the attrs in the javascript.