### PR TITLE
update multi storage backend feature

### DIFF
--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -73,7 +73,7 @@ from seahub.utils import gen_file_get_url, gen_token, gen_file_upload_url, \
 
 from seahub.utils.file_revisions import get_file_revisions_after_renamed
 from seahub.utils.devices import do_unlink_device
-from seahub.utils.repo import get_repo_owner, create_repo_with_storage_backend
+from seahub.utils.repo import get_repo_owner, get_library_storages
 from seahub.utils.star import star_file, unstar_file
 from seahub.utils.file_types import DOCUMENT
 from seahub.utils.file_size import get_file_size_unit
@@ -733,7 +733,19 @@ class Repos(APIView):
                     repo_desc, username, passwd, org_id)
         else:
             if is_pro_version() and ENABLE_STORAGE_CLASSES:
-                repo_id = create_repo_with_storage_backend(request)
+
+                storages = get_library_storages(request)
+                storage_id = request.data.get("storage_id", None)
+                if not storage_id:
+                    storage_id = storages[0]['storage_id']
+
+                if storage_id not in [s['storage_id'] for s in storages]:
+                    error_msg = 'storage_id invalid.'
+                    return api_error(status.HTTP_400_BAD_REQUEST, error_msg)
+
+                repo_id = seafile_api.create_repo(repo_name,
+                        repo_desc, username, passwd, storage_id)
+
             else:
                 repo_id = seafile_api.create_repo(repo_name,
                         repo_desc, username, passwd)
@@ -839,7 +851,18 @@ class PubRepos(APIView):
                 org_id, repo.id, permission)
         else:
             if is_pro_version() and ENABLE_STORAGE_CLASSES:
-                repo_id = create_repo_with_storage_backend(request)
+
+                storages = get_library_storages(request)
+                storage_id = request.data.get("storage_id", None)
+                if not storage_id:
+                    storage_id = storages[0]['storage_id']
+
+                if storage_id not in [s['storage_id'] for s in storages]:
+                    error_msg = 'storage_id invalid.'
+                    return api_error(status.HTTP_400_BAD_REQUEST, error_msg)
+
+                repo_id = seafile_api.create_repo(repo_name,
+                        repo_desc, username, passwd, storage_id)
             else:
                 repo_id = seafile_api.create_repo(repo_name,
                         repo_desc, username, passwd)
@@ -4012,7 +4035,18 @@ class GroupRepos(APIView):
                                            username, permission)
         else:
             if is_pro_version() and ENABLE_STORAGE_CLASSES:
-                repo_id = create_repo_with_storage_backend(request)
+
+                storages = get_library_storages(request)
+                storage_id = request.data.get("storage_id", None)
+                if not storage_id:
+                    storage_id = storages[0]['storage_id']
+
+                if storage_id not in [s['storage_id'] for s in storages]:
+                    error_msg = 'storage_id invalid.'
+                    return api_error(status.HTTP_400_BAD_REQUEST, error_msg)
+
+                repo_id = seafile_api.create_repo(repo_name,
+                        repo_desc, username, passwd, storage_id)
             else:
                 repo_id = seafile_api.create_repo(repo_name,
                         repo_desc, username, passwd)

--- a/seahub/role_permissions/settings.py
+++ b/seahub/role_permissions/settings.py
@@ -2,25 +2,11 @@
 import logging
 
 from django.conf import settings
-from seaserv import seafile_api
-
-from seahub.utils import is_pro_version
 from seahub.constants import DEFAULT_USER, GUEST_USER, \
         DEFAULT_ADMIN, SYSTEM_ADMIN, DAILY_ADMIN, AUDIT_ADMIN
 
-from seahub.settings import ENABLE_STORAGE_CLASSES
-
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
-
-storage_ids = []
-if is_pro_version() and ENABLE_STORAGE_CLASSES:
-    storage_classes = seafile_api.get_all_storage_classes()
-    for s in storage_classes:
-        if s.is_default:
-            storage_ids.insert(0, s.storage_id)
-        else:
-            storage_ids.append(s.storage_id)
 
 DEFAULT_ENABLED_ROLE_PERMISSIONS = {
     DEFAULT_USER: {
@@ -37,7 +23,7 @@ DEFAULT_ENABLED_ROLE_PERMISSIONS = {
         'can_connect_with_ios_clients': True,
         'can_connect_with_desktop_clients': True,
         'can_export_files_via_mobile_client': True,
-        'storage_ids': storage_ids,
+        'storage_ids': [],
         'role_quota': '',
     },
     GUEST_USER: {
@@ -54,7 +40,7 @@ DEFAULT_ENABLED_ROLE_PERMISSIONS = {
         'can_connect_with_ios_clients': False,
         'can_connect_with_desktop_clients': False,
         'can_export_files_via_mobile_client': False,
-        'storage_ids': storage_ids,
+        'storage_ids': [],
         'role_quota': '',
     },
 }

--- a/seahub/views/__init__.py
+++ b/seahub/views/__init__.py
@@ -46,6 +46,7 @@ from seahub.utils import render_permission_error, render_error, \
     is_pro_version, FILE_AUDIT_ENABLED, is_valid_dirent_name, \
     is_org_repo_creation_allowed, is_windows_operating_system
 from seahub.utils.star import get_dir_starred_files
+from seahub.utils.repo import get_library_storages
 from seahub.utils.timeutils import utc_to_local
 from seahub.views.modules import MOD_PERSONAL_WIKI, enable_mod_for_user, \
     disable_mod_for_user
@@ -759,20 +760,8 @@ def libraries(request):
             joined_groups = []
 
     storages = []
-    if is_pro_version() and ENABLE_STORAGE_CLASSES :
-
-        all_storages_dict = {}
-        storage_classes = seafile_api.get_all_storage_classes()
-        for storage in storage_classes:
-            all_storages_dict[storage.storage_id] = storage.storage_name
-
-        for storage_id in request.user.permissions.storage_ids():
-            if storage_id in all_storages_dict.keys():
-                storage_dict = {
-                    'storage_id': storage_id,
-                    'storage_name': all_storages_dict[storage_id],
-                }
-                storages.append(storage_dict)
+    if is_pro_version() and ENABLE_STORAGE_CLASSES:
+        storages = get_library_storages(request)
 
     return render_to_response('libraries.html', {
             "allow_public_share": allow_public_share,


### PR DESCRIPTION
1. If not enable user role feature OR
   haven't configured `storage_ids` option in user role setting:

   Return storage info getted from seafile_api.
   And always put the default storage as the first item in the returned list.

2. If have configured `storage_ids` option in user role setting:

   Only return storage info in `storage_ids`.
   Filter out the wrong stotage id(s).
   Not change the order of the `storage_ids` list.