### PR TITLE
Set autofocus in two factor form with single input field

### DIFF
--- a/seahub/two_factor/templates/two_factor/core/login.html
+++ b/seahub/two_factor/templates/two_factor/core/login.html
@@ -20,7 +20,7 @@
         {% endif %}
 
         <label for="token">{% trans "Authentication token" %}</label>
-        <input id="token" type="text" name="{{form_prefix}}otp_token" value="" class="input two-factor-auth-login-token-input" autocomplete="off" />
+        <input id="token" type="text" name="{{form_prefix}}otp_token" value="" class="input two-factor-auth-login-token-input" autocomplete="off" autofocus="autofocus" />
 
         <label class="checkbox-label remember">
             <input type="checkbox" name="{{form_prefix}}remember_me" class="vam remember-input" />


### PR DESCRIPTION
This enables users to enter the OTP token right after login without manually focusing the single input field.