### PR TITLE
fix-comments-avatar-bug

### DIFF
--- a/frontend/src/css/review-comments.css
+++ b/frontend/src/css/review-comments.css
@@ -117,12 +117,14 @@
   bottom: 0;
   padding-top: 0;
   width: 100%;
+  position: relative;
 }
 .seafile-comment-footer .user-header {
   margin-top: 10px;
+  position: absolute;
 }
 .seafile-comment-footer .seafile-add-comment {
-  margin: 10px 10px 5px 10px;
+  margin: 10px 10px 5px 40px;
   height: 100%;
   width: 100%;
 }


### PR DESCRIPTION
<img width="578" alt="screen shot 2018-10-30 at 21 24 22" src="https://user-images.githubusercontent.com/37589122/47721167-7e751500-dc8a-11e8-8480-1af94f56448a.png">
 
bug：评论栏用户头像宽度为 2em，随着评论栏宽度变化；
