### PR TITLE
update wopi check file info endpoint

### DIFF
--- a/seahub/wopi/views.py
+++ b/seahub/wopi/views.py
@@ -205,6 +205,10 @@ class WOPIFilesView(APIView):
         result['UserCanWrite'] = True if can_edit else False
         result['ReadOnly'] = True if not can_edit else False
 
+        # new file creation feature is not implemented on wopi host(seahub)
+        # hide save as button on view/edit file page
+        result['UserCanNotWriteRelative'] = False
+
         return HttpResponse(json.dumps(result), status=200,
                             content_type=json_content_type)
 


### PR DESCRIPTION
set UserCanNotWriteRelative to false
because new file creation feature is not implemented on wopi host(seahub)