### PR TITLE
Add hint that users need to have logged in at least once before being able to receive shares

### DIFF
--- a/seahub/templates/js/templates.html
+++ b/seahub/templates/js/templates.html
@@ -1404,6 +1404,8 @@
                     <span class="vam">{% trans "Invite People" %}</span>
                 </a>
                 {% endif %}
+                <strong>{% trans "Hint:" %}</strong>
+                {% trans "Users need to login to Seafile at least once before you can share something to them." %}
                 <p class="error hide"></p>
             </div>
 


### PR DESCRIPTION
Add hint that users need to have logged in at least once before being able to receive shares.