### PR TITLE
Fixed folder share notification

### DIFF
--- a/seahub/notifications/templates/notifications/notice_msg/folder_share_msg.html
+++ b/seahub/notifications/templates/notifications/notice_msg/folder_share_msg.html
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans %}{{user}} has shared a folder named <a href="{{url_base}}{{lib_url}}">{{lib_name}}</a> to you.{% endblocktrans %}
+{% load i18n %}{% blocktrans %}{{user}} has shared a folder named <a href="{{url_base}}{{lib_url}}{{lib_name}}">{{lib_name}}</a> to you.{% endblocktrans %}

--- a/seahub/notifications/templates/notifications/notice_msg/folder_share_to_group_msg.html
+++ b/seahub/notifications/templates/notifications/notice_msg/folder_share_to_group_msg.html
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans %}{{user}} has shared a folder named <a href="{{url_base}}{{lib_url}}">{{lib_name}}</a> to group <a href="{{url_base}}{{group_url}}">{{group_name}}</a>.{% endblocktrans %}
+{% load i18n %}{% blocktrans %}{{user}} has shared a folder named <a href="{{url_base}}{{lib_url}}{{lib_name}}">{{lib_name}}</a> to group <a href="{{url_base}}{{group_url}}">{{group_name}}</a>.{% endblocktrans %}


### PR DESCRIPTION
Fix folder share notification -- Folder name must be specified inside html's `<a href=` block