### PR TITLE
fix: properly handle database connection close

### DIFF
--- a/seahub/utils/__init__.py
+++ b/seahub/utils/__init__.py
@@ -521,6 +521,13 @@ def is_org_context(request):
     return request.cloud_mode and request.user.org is not None
 
 # events related
+
+def SeafEventsSession():
+    if EVENTS_CONFIG_FILE:
+        return seafevents.init_db_session_class(EVENTS_CONFIG_FILE)
+    else:
+        raise Exception('SeafEventsSession() requires EVENTS_CONFIG_FILE to be defined')
+
 if EVENTS_CONFIG_FILE:
     parsed_events_conf = ConfigParser.ConfigParser()
     parsed_events_conf.read(EVENTS_CONFIG_FILE)
@@ -528,7 +535,6 @@ if EVENTS_CONFIG_FILE:
     import seafevents
 
     EVENTS_ENABLED = True
-    SeafEventsSession = seafevents.init_db_session_class(EVENTS_CONFIG_FILE)
 
     @contextlib.contextmanager
     def _get_seafevents_session():


### PR DESCRIPTION
* seahub utils __init__ should open a database connection only if it will connect to the database

As discussed per email.
It looks like SeafEventsSession is initialized EVERY time, however not every time, this connection is used, and when is not used is also not closed.

This generates errors on the database backend, which are normally associated with an unexpected application crash and is generating noise in the logs.

I am not sure how this change will affect the rest of the application, this is why I am submitting it through this PR.
