### PR TITLE
adjust my library style in mobile

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import { Router, navigate } from '@reach/router';
+import MediaQuery from 'react-responsive';
+import { Modal } from 'reactstrap';
 import { siteRoot, canAddRepo, isDocs } from './utils/constants';
 import { Utils } from './utils/utils';
 import SystemNotification from './components/system-notification';
@@ -62,6 +64,14 @@ class App extends Component {
     if (event.state && event.state.currentTab && event.state.pathPrefix) {
       let { currentTab, pathPrefix } = event.state;
       this.setState({currentTab, pathPrefix});
+    }
+  }
+
+  componentWillMount() {
+    if (window.screen.width <= 768) {
+      this.setState({
+        isSidePanelClosed: true
+      });
     }
   }
 
@@ -142,6 +152,9 @@ class App extends Component {
       let { currentTab, pathPrefix } = this.state;
       window.history.replaceState({currentTab: currentTab, pathPrefix: pathPrefix}, null);
     });
+    if (window.screen.width <= 768 && !this.state.isSidePanelClosed) {
+      this.setState({ isSidePanelClosed: true });
+    }
   } 
 
   generatorPrefix = (tabName, groupID) => {
@@ -185,8 +198,14 @@ class App extends Component {
     }
   }
 
+  toggleSidePanel = () => {
+    this.setState({
+      isSidePanelClosed: !this.state.isSidePanelClosed
+    });
+  }
+
   render() {
-    let { currentTab } = this.state;
+    let { currentTab, isSidePanelClosed } = this.state;
 
     const home = canAddRepo ?
       <MyLibraries path={ siteRoot } onShowSidePanel={this.onShowSidePanel} onSearchedClick={this.onSearchedClick} /> :
@@ -236,6 +255,9 @@ class App extends Component {
               <InvitationsView path={siteRoot + 'invitations/'} onShowSidePanel={this.onShowSidePanel} onSearchedClick={this.onSearchedClick} />
             </Router>
           </MainPanel>
+          <MediaQuery query="(max-width: 768px)">
+            <Modal isOpen={!isSidePanelClosed} toggle={this.toggleSidePanel} contentClassName="d-none"></Modal>
+          </MediaQuery>
         </div>
       </React.Fragment>
     );

--- a/frontend/src/css/layout.css
+++ b/frontend/src/css/layout.css
@@ -34,8 +34,9 @@
   .side-panel {
     position:fixed;
     left:-300px;
-    z-index: 99; /* important! */
-    width:300px;
+    z-index: 1060;
+    width: 300px;
+    max-width: calc(100% - 40px);
     height:100%;
     background:#f8f8f8;
     -webkit-transition: all 0.3s ease;

--- a/frontend/src/css/toolbar.css
+++ b/frontend/src/css/toolbar.css
@@ -107,3 +107,8 @@
 }
 /* end path toolbar */
 
+@media (max-width: 767px) {
+  .border-left-show:before {
+    width: 0;
+  }
+}

--- a/frontend/src/pages/my-libs/my-libs.js
+++ b/frontend/src/pages/my-libs/my-libs.js
@@ -1,4 +1,5 @@
 import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
 import cookie from 'react-cookies';
 import { seafileAPI } from '../../utils/seafile-api';
 import { gettext, loginUrl} from '../../utils/constants';
@@ -9,6 +10,11 @@ import CommonToolbar from '../../components/toolbar/common-toolbar';
 import RepoViewToolbar from '../../components/toolbar/repo-view-toobar';
 import LibDetail from '../../components/dirent-detail/lib-details';
 import MylibRepoListView from './mylib-repo-list-view';
+
+const propTypes = {
+  onShowSidePanel: PropTypes.func.isRequired,
+  onSearchedClick: PropTypes.func.isRequired,
+};
 
 class MyLibraries extends Component {
   constructor(props) {
@@ -174,5 +180,7 @@ class MyLibraries extends Component {
     );
   }
 }
+
+MyLibraries.propTypes = propTypes;
 
 export default MyLibraries;


### PR DESCRIPTION
On mobile devices:
- Don't show side panel when open app page
- Delete side panel close icon
- When side panel is open, the main panel have a grey shadow. Clicking the shadow can close side panel (Using a modal component).