### PR TITLE
close side panel in mobile

### DIFF
--- a/frontend/src/pages/wiki/main-panel.js
+++ b/frontend/src/pages/wiki/main-panel.js
@@ -79,7 +79,7 @@ class MainPanel extends Component {
               <div className="cur-view-toolbar">
                 <span className="sf2-icon-menu hidden-md-up d-md-none side-nav-toggle" title="Side Nav Menu" onClick={this.onMenuClick}></span>
                 {this.props.permission === 'rw' && (
-                  <button className="btn btn-secondary operation-item" title="Edit" onClick={this.onEditClick}>{gettext('Edit')}</button>
+                  <button className="btn btn-secondary operation-item my-1" title="Edit" onClick={this.onEditClick}>{gettext('Edit')}</button>
                 )}
               </div>
               <CommonToolbar 

--- a/frontend/src/wiki.js
+++ b/frontend/src/wiki.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import moment from 'moment';
+import MediaQuery from 'react-responsive';
+import { Modal } from 'reactstrap';
 import { slug, repoID, siteRoot, initialPath, isDir, sharedToken } from './utils/constants';
 import { Utils } from './utils/utils';
 import { seafileAPI } from './utils/seafile-api';
@@ -44,6 +46,12 @@ class Wiki extends Component {
     window.onpopstate = this.onpopstate;
     this.indexPath = '/index.md';
     this.homePath = '/home.md';
+  }
+
+  componentWillMount() {
+    if (window.screen.width <= 768) {
+      this.setState({ closeSideBar: true });
+    }
   }
 
   componentDidMount() {
@@ -224,6 +232,9 @@ class Wiki extends Component {
       this.showDir(path);
     } else {
       window.location.href = url;
+    }
+    if (!this.state.closeSideBar) {
+      this.setState({ closeSideBar: true });
     }
   }
 
@@ -446,6 +457,9 @@ class Wiki extends Component {
           onMainNavBarClick={this.onMainNavBarClick}
           onDirentClick={this.onDirentClick}
         />
+        <MediaQuery query="(max-width: 768px)">
+          <Modal isOpen={!this.state.closeSideBar} toggle={this.onCloseSide} contentClassName="d-none"></Modal>
+        </MediaQuery>
       </div>
     );
   }


### PR DESCRIPTION
Close wiki side panel in mobile devices. Add modal when side panel is open. Click modal then side panel close.