### PR TITLE
Use a running onlyoffice doc_key during a collaborative editing session.

### DIFF
--- a/seahub/onlyoffice/views.py
+++ b/seahub/onlyoffice/views.py
@@ -108,5 +108,8 @@ def onlyoffice_editor_callback(request):
         # update file
         update_url = gen_inner_file_upload_url('update-api', update_token)
         requests.post(update_url, files=files)
+        # Everyone has left editing session, remove the cached session key
+        if status == 2 and 'oo_session_cache_key' in doc_info:
+            cache.delete(doc_info['oo_session_cache_key'])
 
     return HttpResponse('{"error": 0}')


### PR DESCRIPTION
Use a running OnlyOffice session for concurrent edits of a file.

When a user opens an OnlyOffice document for editing without specifying a version, the session key is cached. Any subsequent user opening the document before the end of the concurrent editing session will use the same doc_key, and join the same editing session.

Currently, if a user saves a document in OnlyOffice through force save or some timeout, the file_id in Seafile changes, and new users opening the document are sent to a different OnlyOffice editing sesison. This leads to forked versions fo the file and users in separate sessions.

See https://github.com/haiwen/seahub/issues/1854 and https://github.com/haiwen/seahub/issues/2957

This has been tested on Seafile 6.3.4 CE. 