### PR TITLE
build: parametrize python & django-admin.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+PYTHON ?= python
+DJANGO_ADMIN_PY ?= django-admin.py
+
 PROJECT=seahub
 
 develop: setup-git
@@ -9,22 +12,22 @@ dist: locale statici18n collectstatic
 
 locale:
 	@echo "--> Compile locales"
-	django-admin.py compilemessages
+	$(DJANGO_ADMIN_PY) compilemessages
 	@echo ""
 
 statici18n:
 	@echo "--> Generate JS locale files in static/scripts/i18n"
-	python manage.py compilejsi18n
+	$(PYTHON) manage.py compilejsi18n
 
 collectstatic:
 	@echo "--> Collect django static files to media/assets"
 	rm -rf media/assets 2> /dev/null
-	python manage.py collectstatic --noinput -i admin -i termsandconditions
+	$(PYTHON) manage.py collectstatic --noinput -i admin -i termsandconditions
 
 compressstatic:
 	@echo "--> Compress static files(css) to media/CACHE"
 	rm -rf media/CACHE 2> /dev/null
-	python manage.py compress
+	$(PYTHON) manage.py compress
 
 clean:
 	@echo '--> Cleaning media/static cache & dist'


### PR DESCRIPTION
This is particularly useful when cross-building Seafile in build-systems
such as OpenWrt or buildroot, where the `python` executable is not in PATH.

Manipulating the PATH variable is also doable but, it's better to provide
the full/absolute path to python, as well as to the django-admin.py script.

This change allows python & django-admin.py to be specified at a different
location, as well as maintaining their default values if unspecified.

Strictly speaking for cross-building, this change is sufficient.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>