### PR TITLE
Enable single sign out when using OpenID Connect

### DIFF
--- a/seahub/auth/views.py
+++ b/seahub/auth/views.py
@@ -249,6 +249,19 @@ def logout(request, next_page=None,
             shib_logout_url += shib_logout_return
         response = HttpResponseRedirect(shib_logout_url)
 
+    # Logout for OAuth user (terminate OAuth session)
+    oauth_logout_url = getattr(settings, 'OAUTH_END_SESSION_URL', '')
+    state_session_has_been_ended = 'openidprovider-done' # This string is arbitrarily chosen
+    if getattr(settings, 'ENABLE_OAUTH', False) and oauth_logout_url:
+        state = request.GET.get('state', '')
+        if state != state_session_has_been_ended:
+            #FIXME When the connection seafile-nginx is http but the connect nginx-user is https, this incorrectly uses 'http'
+            http_or_https = request.is_secure() and 'https' or 'http'
+            seafile_logout_url = http_or_https + '://' + get_current_site(request).domain + settings.SITE_ROOT + getattr(settings, 'LOGOUT_URL', '')
+            oauth_logout_url += '?state=%s&post_logout_redirect_uri=%s' % (urlquote(state_session_has_been_ended, safe = ''), urlquote(seafile_logout_url, safe = ''))
+            response = HttpResponseRedirect(oauth_logout_url)
+            return response
+        
     # Local logout for cas user.
     if getattr(settings, 'ENABLE_CAS', False):
         response = HttpResponseRedirect(reverse('cas_ng_logout'))


### PR DESCRIPTION
This allows the administrator to add the setting OAUTH_END_SESSION_URL. If they do, when users log out, Seahub will try to log them out of their SSO session globally. This is a standard feature of OpenID Connect (so strictly speaking it’s not OAuth). See the [draft for session management](https://openid.net/specs/openid-connect-session-1_0-28.html) (technically it’s a draft and not yet a standard, but it is already deployed in OIDC software).

One problem is that the `http_or_https` variable is not set correctly in some cases (when deploying behind a reverse proxy that terminates the TLS connection). This is very likely handled correctly in other places in Seahub‘s code but I don’t know how.