### PR TITLE
fix: group shares were not shown

### DIFF
--- a/seahub/api2/endpoints/group_libraries.py
+++ b/seahub/api2/endpoints/group_libraries.py
@@ -86,6 +86,7 @@ class GroupLibraries(APIView):
 
         # get repo id owner dict
         all_repo_owner = []
+        all_modifier = []
         repo_id_owner_dict = {}
         for repo in group_repos:
             repo_id = repo.id
@@ -94,7 +95,10 @@ class GroupLibraries(APIView):
                 all_repo_owner.append(repo_owner)
                 repo_id_owner_dict[repo_id] = repo_owner
 
-        all_modifier = [r.last_modifier for r in group_repos]
+            if repo.last_modifier is None:
+                all_modifier.append(repo_owner)
+            else:
+                all_modifier.append(last_modifier)
 
         # Use dict to reduce memcache fetch cost in large for-loop.
         name_dict = {}

--- a/seahub/api2/endpoints/group_libraries.py
+++ b/seahub/api2/endpoints/group_libraries.py
@@ -86,7 +86,6 @@ class GroupLibraries(APIView):
 
         # get repo id owner dict
         all_repo_owner = []
-        all_modifier = []
         repo_id_owner_dict = {}
         for repo in group_repos:
             repo_id = repo.id
@@ -95,16 +94,11 @@ class GroupLibraries(APIView):
                 all_repo_owner.append(repo_owner)
                 repo_id_owner_dict[repo_id] = repo_owner
 
-            if repo.last_modifier is None:
-                all_modifier.append(repo_owner)
-            else:
-                all_modifier.append(last_modifier)
-
         # Use dict to reduce memcache fetch cost in large for-loop.
         name_dict = {}
         contact_email_dict = {}
 
-        for email in set(all_repo_owner + all_modifier):
+        for email in all_repo_owner:
 
             if email not in name_dict:
                 if '@seafile_group' in email:
@@ -136,7 +130,7 @@ class GroupLibraries(APIView):
             group_repo_info['owner_name'] = name_dict.get(repo_owner, '')
             group_repo_info['owner_contact_email'] = contact_email_dict.get(repo_owner, '')
 
-            modifier = group_repo.last_modifier
+            modifier = repo_owner
             group_repo_info['modifier_email'] = modifier
             group_repo_info['modifier_name'] = name_dict.get(modifier, '')
             group_repo_info['modifier_contact_email'] = contact_email_dict.get(modifier, '')


### PR DESCRIPTION
Code works on my deployment. It might have other not-thought-of-consequences, though. It's taken from here, so that everyone can profit from the bugfix: https://forum.seafile.com/t/error-in-seahub-when-accessing-group-shares/9540