### PR TITLE
Use string.endswith to check path normalization.

### DIFF
--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -4077,7 +4077,7 @@ class SharedDirView(APIView):
 
         req_path = request.GET.get('p', '/')
 
-        if req_path[-1] != '/':
+        if not req_path.endswith('/'):
             req_path += '/'
 
         if req_path == '/':

--- a/seahub/views/repo.py
+++ b/seahub/views/repo.py
@@ -55,7 +55,8 @@ def is_password_set(repo_id, username):
 
 def get_path_from_request(request):
     path = request.GET.get('p', '/')
-    if path[-1] != '/':
+
+    if not path.endswith('/'):
         path = path + '/'
     return path
 
@@ -261,9 +262,7 @@ def view_shared_dir(request, fileshare):
 
     # Get path from frontend, use '/' if missing, and construct request path
     # with fileshare.path to real path, used to fetch dirents by RPC.
-    req_path = request.GET.get('p', '/')
-    if req_path[-1] != '/':
-        req_path += '/'
+    req_path = get_path_from_request(request)
 
     if req_path == '/':
         real_path = fileshare.path


### PR DESCRIPTION
When we encounter an empty path, like `https://demo.seafile.top/d/c56fc44545456ffea123/?p=`, the path string will have a length of 0. Using `path[-1]` index to check the last character will cause an internal server error (index out of bounds), so we probably should use `endswith` instead.

This should fix https://forum.seafile.com/t/internal-server-error-7-1-3/11368/16 and #4478.