### PR TITLE
[shared video file view] add missing video-file-view class

### DIFF
--- a/frontend/src/shared-file-view-video.js
+++ b/frontend/src/shared-file-view-video.js
@@ -29,7 +29,7 @@ class FileContent extends React.Component {
       }]
     };
     return (
-      <div className="shared-file-view-body d-flex">
+      <div className="shared-file-view-body d-flex video-file-view">
         <div className="flex-1">
           <VideoPlayer { ...videoJsOptions } />
         </div>


### PR DESCRIPTION
The video-file-view css class is missing in the shared video file view so video-js player is not correctly resized.