### PR TITLE
Thumbnail support for HEIC/HEIF images

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -10,8 +10,6 @@ import './assets/css/fontawesome.css';
 import './index.css';
 
 ReactDOM.render(
-  <I18nextProvider i18n={ i18n } >
-    <MarkdownEditor />
-  </I18nextProvider>,
+  <I18nextProvider i18n={ i18n } > <MarkdownEditor /> </I18nextProvider>,
   document.getElementById('root')
 );

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -10,6 +10,8 @@ import './assets/css/fontawesome.css';
 import './index.css';
 
 ReactDOM.render(
-  <I18nextProvider i18n={ i18n } > <MarkdownEditor /> </I18nextProvider>,
+  <I18nextProvider i18n={ i18n } >
+    <MarkdownEditor />
+  </I18nextProvider>,
   document.getElementById('root')
 );

--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -99,6 +99,7 @@ export const Utils = {
     'gif' : 'pic.png',
     'bmp' : 'pic.png',
     'ico' : 'pic.png',
+    'heic' : 'pic.png',
 
     // default
     'default' : 'file.png'
@@ -111,7 +112,7 @@ export const Utils = {
       return false;
     }
     var file_ext = filename.substr(filename.lastIndexOf('.') + 1).toLowerCase();
-    var image_exts = ['gif', 'jpeg', 'jpg', 'png', 'ico', 'bmp', 'tif', 'tiff'];
+    var image_exts = ['gif', 'jpeg', 'jpg', 'png', 'ico', 'bmp', 'tif', 'tiff', 'heic'];
     if (image_exts.indexOf(file_ext) != -1) {
       return true;
     } else {

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pillow
 pyjwt
 pycryptodome
 requests_oauthlib
+pyheif-pillow-opener==0.1.0

--- a/seahub/thumbnail/utils.py
+++ b/seahub/thumbnail/utils.py
@@ -232,7 +232,7 @@ def _create_thumbnail_common(fp, thumbnail_file, size):
     if image_memory_cost > THUMBNAIL_IMAGE_ORIGINAL_SIZE_LIMIT:
         return (False, 403)
 
-    if image.mode not in ["1", "L", "P", "RGB", "RGBA"]: # remove RGBA for jpeg
+    if image.mode not in ["1", "L", "P", "RGB", "RGBA"]:
         image = image.convert("RGB")
 
     image = get_rotated_image(image)

--- a/seahub/thumbnail/utils.py
+++ b/seahub/thumbnail/utils.py
@@ -10,11 +10,16 @@ import zipfile
 try: # Py2 and Py3 compatibility
     from urllib.request import urlretrieve
 except:
-    from urllib.request import urlretrieve
+    from urllib import urlretrieve
 
 from PIL import Image
 from seaserv import get_file_id_by_path, get_repo, get_file_size, \
     seafile_api
+
+from pyheif_pillow_opener import register_heif_opener
+
+register_heif_opener()
+
 
 from seahub.utils import gen_inner_file_get_url, get_file_type_and_ext
 from seahub.utils.file_types import VIDEO, XMIND
@@ -227,7 +232,7 @@ def _create_thumbnail_common(fp, thumbnail_file, size):
     if image_memory_cost > THUMBNAIL_IMAGE_ORIGINAL_SIZE_LIMIT:
         return (False, 403)
 
-    if image.mode not in ["1", "L", "P", "RGB", "RGBA"]:
+    if image.mode not in ["1", "L", "P", "RGB", "RGBA"]: # remove RGBA for jpeg
         image = image.convert("RGB")
 
     image = get_rotated_image(image)

--- a/seahub/utils/__init__.py
+++ b/seahub/utils/__init__.py
@@ -123,7 +123,7 @@ EMPTY_SHA1 = '0000000000000000000000000000000000000000'
 MAX_INT = 2147483647
 
 PREVIEW_FILEEXT = {
-    IMAGE: ('gif', 'jpeg', 'jpg', 'png', 'ico', 'bmp', 'tif', 'tiff', 'psd'),
+    IMAGE: ('gif', 'jpeg', 'jpg', 'png', 'ico', 'bmp', 'tif', 'tiff', 'psd', 'heic'),
     DOCUMENT: ('doc', 'docx', 'ppt', 'pptx', 'odt', 'fodt', 'odp', 'fodp'),
     SPREADSHEET: ('xls', 'xlsx', 'ods', 'fods'),
     SVG: ('svg',),


### PR DESCRIPTION
HEIC/HEIF format is widely used among iOS users, but there's no thumbnail support for this format till now.  With Python library pyheif_pillow_opener, I found a simple and seamless way to integrate HEIF support to Pillow.