### PR TITLE
Fix wopi/utils.py for python 3.9

### DIFF
--- a/seahub/wopi/utils.py
+++ b/seahub/wopi/utils.py
@@ -108,7 +108,7 @@ def get_wopi_dict(request_user, repo_id, file_path,
             logger.error(e)
             return None
 
-        for action in root.getiterator('action'):
+        for action in root.iter('action'):
             attr = action.attrib
             ext = attr.get('ext')
             name = attr.get('name')


### PR DESCRIPTION
This replaces a removed method (see https://docs.python.org/3.9/whatsnew/3.9.html#removed-in-python-39 and https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getiterator) with its successor which should be a drop-in replacement (judging from the docs).

As far as I can see this is the only place that needs fixing for full support of python 3.9. In fact, I'm running the current seafile & seahub under 3.9 and noticed this just because I enabled the collabora office integration.

Because the replacement method was there for a long time (since python 3.2 (02/2011), debian wheezy and later has it etc.) there should be minimal risk in changing that.