### PR TITLE
make collabora view available for editable formats, fixes #4627

### DIFF
--- a/seahub/wopi/utils.py
+++ b/seahub/wopi/utils.py
@@ -123,6 +123,15 @@ def get_wopi_dict(request_user, repo_id, file_path,
 
                 if wopi_key == tmp_wopi_key:
                     action_url = tmp_action_url
+
+                # if edit is possible we can also view the filie
+                if name == 'edit':
+                    tmp_wopi_key = generate_discovery_cache_key('view', ext)
+                    cache.set(tmp_wopi_key, tmp_action_url,
+                            OFFICE_WEB_APP_DISCOVERY_EXPIRATION)
+                    if wopi_key == tmp_wopi_key:
+                        action_url = tmp_action_url
+
             else:
                 continue
 


### PR DESCRIPTION
This fixes #4627
This is a fixed version of the PR #4816 

collabora online provides only one action to edit an file extension and implies that view is also possible.
so if the action allows edit we also use the provided action to view