### PR TITLE
fix onlyoffice cache timeout

### DIFF
--- a/seahub/onlyoffice/views.py
+++ b/seahub/onlyoffice/views.py
@@ -135,7 +135,7 @@ def onlyoffice_editor_callback(request):
         # 6 - document is being edited, but the current document state is saved,
         if status == 6:
             # cache document key when forcesave
-            cache.set(cache_key, doc_key)
+            cache.set(cache_key, doc_key, None)
 
     # 4 - document is closed with no changes,
     if status == 4:


### PR DESCRIPTION
When opening a document, the cache timeout is set to None so the key never
expires. However when force save is received, the cache timeout is not set so
it defaults to 300. When a new user opens the document after this timeout, a
new cache key is generated and a new editing session is created.

Set cache timeout to None in onlyoffice_editor_callback so cache key never
expires.