### PR TITLE
Use comma as html meta keyword separator

### DIFF
--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -4267,7 +4267,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "المعذرة، و لكن لا يمكن العثور على الصفحة المطلوية."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "تنظيم فريق اشتراك ملف"
 
 #: seahub/templates/base.html:39

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -4238,7 +4238,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr ""
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr ""
 
 #: seahub/templates/base.html:39

--- a/locale/ca/LC_MESSAGES/django.po
+++ b/locale/ca/LC_MESSAGES/django.po
@@ -4239,7 +4239,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "No s'ha pogut localitzar la pàgina sol·licitada."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "Equip d'organització de fitxers"
 
 #: seahub/templates/base.html:39

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -4257,8 +4257,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Požadovaná stránka nebyla nalezena."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Práce se soubory a týmová organizace"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Soubor, Spolupráce, Tým, Organizace"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -4307,8 +4307,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Es tut uns leid, aber die angefragte Seite wurde nicht gefunden."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Datei, Zusammenarbeit, Team, Organisation"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -4243,7 +4243,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Συγγνώμη, αλλά η σελίδα που ζητήσατε δεν μπορεί να βρεθεί."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr ""
 
 #: seahub/templates/base.html:39

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -4400,7 +4400,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr ""
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr ""
 
 #: seahub/templates/base.html:39

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -4245,8 +4245,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "La página solicitada no pudo ser encontrada."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Organización de equipo de colaboraores"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Archivo, Colaboración, Equipo, Organización"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -4242,8 +4242,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "La página solicitada no pudo ser encontrada."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Organización de equipo de colaboraores"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Archivo, Colaboración, Equipo, Organización"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/es_MX/LC_MESSAGES/django.po
+++ b/locale/es_MX/LC_MESSAGES/django.po
@@ -4243,8 +4243,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "La página solicitada no puede ser encontrada."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Organización de equipo de colaboraores"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Archivo, Colaboración, Equipo, Organización"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -4242,8 +4242,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Pahoittelut, mutta pyytämääsi sivua ei löydy."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Tiedosto Yhteistyö Tiimi Organisaatio"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Tiedosto, Yhteistyö, Tiimi, Organisaatio"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -4266,8 +4266,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Désolé, mais la page demandée est introuvable."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Organisation des fichiers de collaboration d'équipe"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Fichier, Collaboration, Équipe, Organisation"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -4254,7 +4254,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr ""
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr ""
 
 #: seahub/templates/base.html:39

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -4247,8 +4247,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Sajnáljuk, a kért oldal nem található."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Fájlmegosztó szervezet "
+msgid "File, Collaboration, Team, Organization"
+msgstr "Fájl, Együttműködés, Csapat, Szervezés"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/is/LC_MESSAGES/django.po
+++ b/locale/is/LC_MESSAGES/django.po
@@ -4240,8 +4240,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Afsakið, en síðan sem þú baðst um fannst ekki."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Skrá Samvinna Teymi Samfélag"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Skrá, Samstarf, Teymi, Skipulag"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -4243,8 +4243,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Spiacenti, la pagina richiesta non è stata trovata."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
+msgstr "File, Collaborazione, Squadra, Organizzazione"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -4236,7 +4236,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr ""
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "ファイル連携するチームの組織"
 
 #: seahub/templates/base.html:39

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -4233,7 +4233,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "죄송합니다만, 요청한 페이지가 없습니다."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "파일 협업 팀 조직"
 
 #: seahub/templates/base.html:39

--- a/locale/lt/LC_MESSAGES/django.po
+++ b/locale/lt/LC_MESSAGES/django.po
@@ -4254,7 +4254,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr ""
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr ""
 
 #: seahub/templates/base.html:39

--- a/locale/lv/LC_MESSAGES/django.po
+++ b/locale/lv/LC_MESSAGES/django.po
@@ -4245,8 +4245,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Atvainojiet, bet pieprasīto lapu nevarēja atrast."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Datņu koplietošana"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Faili, Sadarbība, Komanda, Organizēšana"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/mk/LC_MESSAGES/django.po
+++ b/locale/mk/LC_MESSAGES/django.po
@@ -4237,7 +4237,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr ""
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr ""
 
 #: seahub/templates/base.html:39

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -4237,7 +4237,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr ""
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr ""
 
 #: seahub/templates/base.html:39

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -4257,8 +4257,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Niestety, żądana strona nie została odnaleziona."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "praca grupowa organizacja współpraca"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Plik, Współpraca, Zespół, Organizacja"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -4253,8 +4253,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Desculpe, mas a página requisitada não pode ser encontrada."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Equipe de colaboração"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Arquivo, Colaboração, Equipe, Organização"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -4269,7 +4269,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Извините, но запрошенная страница не может быть найдена."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "Совместный файл сообщества"
 
 #: seahub/templates/base.html:39

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -193,8 +193,8 @@ msgid "繁體中文"
 msgstr "Čínsky"
 
 #: seahub/api2/templates/api2/base.html:8 seahub/templates/base.html:9
-msgid "File Collaboration Team Organization"
-msgstr ""
+msgid "File, Collaboration, Team, Organization"
+msgstr "Súbor, Spolupráca, Tím, Organizácia"
 
 #: seahub/api2/templates/api2/discussion.html:6
 #: seahub/group/templates/group/group_base.html:25

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -226,8 +226,8 @@ msgid "繁體中文"
 msgstr "繁體中文"
 
 #: seahub/api2/templates/api2/base.html:8 seahub/templates/base.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Datoteka Sodelovanje Ekipa Organizacija"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Datoteka, Sodelovanje, Ekipa, Organizacija"
 
 #: seahub/api2/templates/api2/discussion.html:6
 #: seahub/group/templates/group/group_base.html:23

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -4243,8 +4243,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Ledsen, den önskade sidan hittas inte."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Samarbetande Team"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Fil, Samarbete, Team, Organisation"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/th/LC_MESSAGES/django.po
+++ b/locale/th/LC_MESSAGES/django.po
@@ -231,7 +231,7 @@ msgid "繁體中文"
 msgstr "จีนตัวเต็ม"
 
 #: seahub/api2/templates/api2/base.html:8 seahub/templates/base.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "องค์การร่วมกันทำงานบนแฟ้มเอกสาร"
 
 #: seahub/api2/templates/api2/discussion.html:6

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -4240,8 +4240,8 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Üzgünüm, ama istediğiniz sayfa bulunamadı."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
-msgstr "Dosya Kolabrasyon Takım Organizasyonu"
+msgid "File, Collaboration, Team, Organization"
+msgstr "Dosya, Kolabrasyon, Takım, Organizasyonu"
 
 #: seahub/templates/base.html:39
 msgid "Side Nav Menu"

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -4257,7 +4257,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Вибачте, але такої сторінки не знайдено."
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "Спільний файл команди спільноти"
 
 #: seahub/templates/base.html:39

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -4230,7 +4230,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "Không thể tìm thấy trang được yêu cầu"
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "Tổ chức file phối hợp Group"
 
 #: seahub/templates/base.html:39

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -4244,7 +4244,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "对不起，你访问的页面不存在。"
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "文件 合作 团队 团体"
 
 #: seahub/templates/base.html:39

--- a/locale/zh_TW/LC_MESSAGES/django.po
+++ b/locale/zh_TW/LC_MESSAGES/django.po
@@ -4237,7 +4237,7 @@ msgid "Sorry, but the requested page could not be found."
 msgstr "對不起，你瀏覽的頁面不存在。"
 
 #: seahub/templates/base.html:8 seahub/templates/base_for_react.html:9
-msgid "File Collaboration Team Organization"
+msgid "File, Collaboration, Team, Organization"
 msgstr "檔案 合作 團隊 團體"
 
 #: seahub/templates/base.html:39

--- a/seahub/templates/base.html
+++ b/seahub/templates/base.html
@@ -5,7 +5,7 @@
 <head>
 <title>{% block sub_title %}{% endblock %}{{ site_title }}</title>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-<meta name="keywords" content="{% trans "File Collaboration Team Organization" %}" />
+<meta name="keywords" content="{% trans "File, Collaboration, Team, Organization" %}" />
 {% block viewport %}
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 {% endblock %}

--- a/seahub/templates/base_for_react.html
+++ b/seahub/templates/base_for_react.html
@@ -6,7 +6,7 @@
 <head>
 <title>{% block sub_title %}{% endblock %}{{ site_title }}</title>
 <meta http-equiv="Content-type" content="text/html; charset=utf-8" />
-<meta name="keywords" content="{% trans "File Collaboration Team Organization" %}" />
+<meta name="keywords" content="{% trans "File, Collaboration, Team, Organization" %}" />
 {% block viewport %}
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 {% endblock %}


### PR DESCRIPTION
As per
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name this
it the correct character to separate the keywords listed there.

I also updated some of the translation strings (but not those with
non-latin character sets, sorry).