### PR TITLE
Fix ocm-provider response not being returned

### DIFF
--- a/seahub/ocm_via_webdav/ocm_api.py
+++ b/seahub/ocm_via_webdav/ocm_api.py
@@ -151,7 +151,8 @@ class OCMProviderView(APIView):
                     'shareTypes': ['user'],
                 }
             }
-            return Response(result)
+
+        return Response(result)
 
 
 class SharesView(APIView):


### PR DESCRIPTION
Right now the response is only returned if `ENABLE_OCM_VIA_WEBDAV` is `True`. If only `ENABLE_OCM` is `True` this results in the following error:
```
AssertionError: Expected a `Response`, `HttpResponse` or `HttpStreamingResponse` to be returned from the view, but received a `<class 'NoneType'>`
```

This PR fixes this, so the response is returned in all cases.