### PR TITLE
Use full URI in oauth authorization_response

### DIFF
--- a/seahub/oauth/views.py
+++ b/seahub/oauth/views.py
@@ -130,7 +130,7 @@ def oauth_callback(request):
         token = session.fetch_token(
             TOKEN_URL,
             client_secret=CLIENT_SECRET,
-            authorization_response=request.get_full_path())
+            authorization_response=request.build_absolute_uri())
 
         if 'user_id' in session._client.__dict__['token']:
             # used for sjtu.edu.cn


### PR DESCRIPTION
authorization_response parameter should be "The full URL of the redirect back to you" because it checks for secure transport.

fixes #5083