### PR TITLE
Fix share links with OnlyOffice 7.1

### DIFF
--- a/seahub/onlyoffice/utils.py
+++ b/seahub/onlyoffice/utils.py
@@ -168,7 +168,7 @@ def get_onlyoffice_dict(request, username, repo_id, file_path, file_id='',
             "editorConfig": {
                 "callbackUrl": callback_url,
                 "lang": request.LANGUAGE_CODE,
-                "mode": can_edit,
+                "mode": 'edit' if can_edit else 'view',
                 "customization": {
                     "forcesave": ONLYOFFICE_FORCE_SAVE,
                 },


### PR DESCRIPTION
mode must be either 'edit' or 'view'. Prevents auth missing required
parameter editorConfig.mode (since 7.1 version) error when opening a
share link pointing on an office document

See https://forum.seafile.com/t/seafile-9-onlyoffice-7-1-cant-open-publicly-shared-docs/16521