### PR TITLE
add "lang=" in  wopi url

### DIFF
--- a/seahub/wopi/utils.py
+++ b/seahub/wopi/utils.py
@@ -188,7 +188,7 @@ def get_wopi_dict(request_user, repo_id, file_path,
     }
     WOPI_UI_LLCC = lang_dict[language_code]
 
-    full_action_url += '&ui=%s&rs=%s' % (WOPI_UI_LLCC, WOPI_UI_LLCC)
+    full_action_url += '&ui=%s&rs=%s&lang=%s' % (WOPI_UI_LLCC, WOPI_UI_LLCC, WOPI_UI_LLCC)
 
     # generate access token
     user_repo_path_info = {


### PR DESCRIPTION
I've deployed collabora online development edition using docker, but after version 22.05.9.2.1, WebUI can only display in english.
After some googling, a [forum of collaboraonline](https://forum.collaboraonline.com/t/ui-default-language/1664/4) had mention a parameter needs to be added in url.

Change in seafile-server-latest/seahub/seahub/wopi/utils.py can makes locale correctly displayed.
