### PR TITLE
seahub.sh: increase sleep time for "stop"

### DIFF
--- a/scripts/seahub.sh
+++ b/scripts/seahub.sh
@@ -223,7 +223,7 @@ function stop_seahub () {
     if [[ -f ${pidfile} ]]; then
         echo "Stopping seahub ..."
         pkill -f "thirdpart/bin/gunicorn"
-        sleep 1
+        sleep 5
         if pgrep -f "thirdpart/bin/gunicorn" 2>/dev/null 1>&2 ; then
             echo 'Failed to stop seahub.'
             exit 1


### PR DESCRIPTION
The one second sleep between the "pkill" and "pgrep" check is too short for lower-power systems like Raspberry Pi. Increase to five seconds, to match "start" sleep time.