### PR TITLE
wopi: Send the avatar for collaborative editing

### DIFF
--- a/seahub/wopi/views.py
+++ b/seahub/wopi/views.py
@@ -21,6 +21,7 @@ from django.core.cache import cache
 from pysearpc import SearpcError
 from seaserv import seafile_api
 
+from seahub.avatar.templatetags.avatar_tags import api_avatar_url
 from seahub.base.accounts import User, ANONYMOUS_EMAIL
 from seahub.base.templatetags.seahub_tags import email2nickname
 from seahub.utils import gen_inner_file_get_url, gen_inner_file_upload_url, \
@@ -256,6 +257,9 @@ class WOPIFilesView(APIView):
         result['SupportsUpdate'] = True if can_edit else False
         result['UserCanWrite'] = True if can_edit else False
         result['ReadOnly'] = True if not can_edit else False
+
+        avatar_url, _, _ = api_avatar_url(request_user, int(72))
+        result['UserExtraInfo'] = { 'avatar': avatar_url, 'mail': request_user }
 
         # new file creation feature is not implemented on wopi host(seahub)
         # hide save as button on view/edit file page


### PR DESCRIPTION
This PR will allow Seafile to send the avatar to Collabora Online to that is gets displayed, like this:

![image](https://github.com/haiwen/seahub/assets/114441/3b79d8bb-a694-4f2b-8aca-77020ff14bb1)

See https://sdk.collaboraonline.com/docs/advanced_integration.html#userextrainfo

I have tested this with Seafile `v11.0.0-server` and `master`, against Collabora Online 23.05 (my local development build).

This is a submission on behalf of Collabora Productivity.