### PR TITLE
[dir view, other pages] fixed problems 'cannot close the notice popover

### DIFF
--- a/frontend/src/components/common/notification-popover/index.js
+++ b/frontend/src/components/common/notification-popover/index.js
@@ -23,19 +23,15 @@ export default class NotificationPopover extends React.Component {
   };
 
   componentDidMount() {
-    document.addEventListener('mousedown', this.handleOutsideClick);
+    document.addEventListener('mousedown', this.handleOutsideClick, true);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('mousedown', this.handleOutsideClick);
+    document.removeEventListener('mousedown', this.handleOutsideClick, true);
   }
 
   handleOutsideClick = (e) => {
-    if (!this.notificationContainerRef.contains(e.target)) {
-      document.removeEventListener('mousedown', this.handleOutsideClick);
-      if (e.target.className === 'tool notification' || e.target.parentNode.className === 'tool notification') {
-        return;
-      }
+    if (!this.notificationContainerRef.contains(e.target) && !document.getElementById('notice-icon').contains(e.target)) {
       this.props.onNotificationListToggle();
     }
   };


### PR DESCRIPTION
via clicking the bell icon, or via clicking outside'

- in 'dir view', clicking the notice bell icon, clicking the content(dirents) area, the notice popover was not closed
- in other pages, clicking the notice bell icon, the popover was not closed