### PR TITLE
[library 'Folder Permission' dialog] fixup: enable users to 'choose' …

### DIFF
--- a/frontend/src/components/dialog/lib-sub-folder-set-group-permission-dialog.js
+++ b/frontend/src/components/dialog/lib-sub-folder-set-group-permission-dialog.js
@@ -77,11 +77,8 @@ class GroupItem extends React.Component {
 GroupItem.propTypes = {
   item: PropTypes.object.isRequired,
   permissions: PropTypes.array.isRequired,
-  deleteUserFolderPermission: PropTypes.func.isRequired,
-  onChangeUserFolderPerm: PropTypes.func.isRequired,
   showPath: PropTypes.bool.isRequired,
   repoName: PropTypes.string.isRequired,
-  handleChange: PropTypes.func.isRequired,
   deleteGroupPermissionItem: PropTypes.func.isRequired,
   onChangeGroupPermission: PropTypes.func.isRequired,
 };
@@ -247,6 +244,7 @@ class LibSubFolderSetGroupPermissionDialog extends React.Component {
 
   handleSubmit = () => {
     this.setState({
+      folderPath: this.state.folderPath || '/',
       showFileChooser: !this.state.showFileChooser
     });
   };

--- a/frontend/src/components/dialog/lib-sub-folder-set-user-permission-dialog.js
+++ b/frontend/src/components/dialog/lib-sub-folder-set-user-permission-dialog.js
@@ -82,14 +82,13 @@ UserItem.propTypes = {
   onChangeUserFolderPerm: PropTypes.func.isRequired,
   showPath: PropTypes.bool.isRequired,
   repoName: PropTypes.string.isRequired,
-  handleChange: PropTypes.func.isRequired,
 };
 
 
 const propTypes = {
   repoID: PropTypes.string.isRequired,
   isDepartmentRepo: PropTypes.bool,
-  folderPath: PropTypes.string.isRequired,
+  folderPath: PropTypes.string,
   repoName: PropTypes.string,
 };
 
@@ -226,6 +225,7 @@ class LibSubFolderSetUserPermissionDialog extends React.Component {
 
   handleFileChooserSubmit = () => {
     this.setState({
+      folderPath: this.state.folderPath || '/',
       showFileChooser: !this.state.showFileChooser
     });
   };


### PR DESCRIPTION
…the root folder; removed those unused prop type checking which caused errors