### PR TITLE
support comma-separated value for seafile_groups claim

### DIFF
--- a/seahub/adfs_auth/backends.py
+++ b/seahub/adfs_auth/backends.py
@@ -194,6 +194,10 @@ class Saml2Backend(ModelBackend):
         if not seafile_groups:
             return
 
+        # support a list of comma-separated IDs as seafile_groups claim
+        if len(seafile_groups) == 1 and ',' in seafile_groups[0]:
+            seafile_groups = seafile_groups[0].split(',')
+
         saml_group_ids = [int(group_id) for group_id in seafile_groups]
 
         joined_groups = ccnet_api.get_groups(user.username)


### PR DESCRIPTION
IDPs like Entra ID don't support multi-value claims except for group membership, but those values don't match up easily with Seafile group IDs.

This commit support a single-value input for seafile_groups to contain commas as separator, so it can easily be used with Entra ID static values and transformations like `Join()`.