### PR TITLE
Append extra settings for seahub

### DIFF
--- a/scripts/setup-seafile-mysql.py
+++ b/scripts/setup-seafile-mysql.py
@@ -1030,6 +1030,7 @@ class SeahubConfigurator(AbstractConfigurator):
         self.admin_email = ''
         self.admin_password = ''
         self.seahub_settings_py = os.path.join(env_mgr.central_config_dir, 'seahub_settings.py')
+        self.seahub_settings_extra_py = os.path.join(env_mgr.central_config_dir, 'seahub_settings_extra.py')
 
     def ask_questions(self):
         pass
@@ -1045,6 +1046,7 @@ class SeahubConfigurator(AbstractConfigurator):
             fp.write('SERVICE_URL = "http://%s"' % ccnet_config.ip_or_domain)
             fp.write('\n')
             self.write_database_config(fp)
+            self.write_extra_config(fp)
 
     def write_utf8_comment(self, fp):
         fp.write('# -*- coding: utf-8 -*-')
@@ -1080,6 +1082,14 @@ class SeahubConfigurator(AbstractConfigurator):
                                port=db_config.mysql_port)
 
         fp.write(text)
+
+    def write_extra_config(self, fp):
+        try:
+            with open(self.seahub_settings_extra_py) as fp_extra:
+                fp.write('\n')
+                fp.writelines(fp_extra.readlines())
+        except FileNotFoundError:
+            pass
 
     def ask_admin_email(self):
         print()


### PR DESCRIPTION
If `seahub_settings_extra.py` exists, it is automatically added at the end of the generated `seahub_settings.py`

By this way, it is no more required : 
- to write manually the extra settings at the end of the `seahub_settings.py` 
- and to restart the service

as described [here](https://manual.seafile.com/deploy/only_office/#configure-seafile-server).

This is useful when seafile is deployed with a docker compose file: instead of starting the container and manually doing a `docker exec` to edit the `seahub_settings.py` inside the container and restarting the service, we just provide a seahub_settings_extra.py with the docker 'volume' feature.