### PR TITLE
[select-editor, link details] fixup: display the current option right…

### DIFF
--- a/frontend/src/components/select-editor/select-editor.js
+++ b/frontend/src/components/select-editor/select-editor.js
@@ -107,8 +107,6 @@ class SelectEditor extends React.Component {
 
   render() {
     let { currentOption, isTextMode } = this.props;
-    // scence1: isTextMode (text)editor-icon --> select
-    // scence2: !isTextMode select
     return (
       <div className="permission-editor" onClick={this.onSelectHandler}>
         {(!isTextMode || this.state.isEditing) &&
@@ -116,8 +114,7 @@ class SelectEditor extends React.Component {
             options={this.state.options}
             className="permission-editor-select"
             classNamePrefix="permission-editor"
-            placeholder={this.props.translateOption(currentOption)}
-            value={currentOption}
+            value={this.state.options.filter(item => item.value == currentOption)[0]}
             onChange={this.onOptionChanged}
             captureMenuScroll={false}
             menuPlacement="auto"

--- a/frontend/src/components/share-link-panel/link-details.js
+++ b/frontend/src/components/share-link-panel/link-details.js
@@ -251,7 +251,7 @@ class LinkDetails extends React.Component {
           )}
           {sharedLinkInfo.permissions && (
             <>
-              <dt className="text-secondary font-weight-normal">{gettext('Permission:')}</dt>
+              <dt className="text-secondary font-weight-normal">{gettext('Permission')}</dt>
               <dd>
                 <div className="w-50">
                   <SelectEditor

--- a/frontend/src/css/select-editor.css
+++ b/frontend/src/css/select-editor.css
@@ -7,10 +7,16 @@
   word-wrap: break-word;
   white-space: pre-wrap;
 }
+
+.permission-editor__option--is-selected .permission-editor-explanation {
+  color: inherit;
+}
+
 .permission-editor .permission-editor__option {
   padding-top: 2px;
   padding-bottom: 2px;
 }
+
 .permission-editor .permission-editor__control .permission-editor-explanation {
   display: none;
 }


### PR DESCRIPTION
…ly for the 'select-editor'; removed ':' after 'Permission' for 'link details'