### PR TITLE
['dir view' page] don't display the 'views' module for group members …

### DIFF
--- a/frontend/src/components/dir-view-mode/dir-views.js
+++ b/frontend/src/components/dir-view-mode/dir-views.js
@@ -26,7 +26,9 @@ const DirViews = ({ userPerm, repoID, currentPath, currentRepoInfo }) => {
     setSettingsDialogOpen(true);
   }, []);
 
-  if (!enableMetadataManagement) return null;
+  if (!enableMetadataManagement || (!enableMetadata && !currentRepoInfo.is_admin)) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
…when the 'metadata' feature is not turned on