### PR TITLE
fix re-usage of SSO-based accounts for LDAP login

### DIFF
--- a/seahub/base/accounts.py
+++ b/seahub/base/accounts.py
@@ -63,6 +63,8 @@ ANONYMOUS_EMAIL = 'Anonymous'
 
 UNUSABLE_PASSWORD = '!'  # This will never be a valid hash
 
+SSO_LDAP_USE_SAME_UID = getattr(settings, 'SSO_LDAP_USE_SAME_UID', False)
+
 
 def default_ldap_role_mapping(role):
     return role
@@ -964,6 +966,8 @@ class CustomLDAPBackend(object):
         # search user from ldap server
         try:
             auth_user = SocialAuthUser.objects.filter(username=ldap_user, provider=LDAP_PROVIDER).first()
+            if not auth_user and SSO_LDAP_USE_SAME_UID:
+                auth_user = SocialAuthUser.objects.filter(username=ldap_user).first()
             if auth_user:
                 login_attr = auth_user.uid
             else:
@@ -977,6 +981,8 @@ class CustomLDAPBackend(object):
         except Exception as e:
             if ENABLE_MULTI_LDAP:
                 auth_user = SocialAuthUser.objects.filter(username=ldap_user, provider=MULTI_LDAP_1_PROVIDER).first()
+                if not auth_user and SSO_LDAP_USE_SAME_UID:
+                    auth_user = SocialAuthUser.objects.filter(username=ldap_user).first()
                 if auth_user:
                     login_attr = auth_user.uid
                 else:


### PR DESCRIPTION
In pull request #6903 the SSO_LDAP_USE_SAME_UID field was introduced.

But this change only took care for the following order of login actitivies:

1. login via LDAP -> account is created
2. login via SSO -> account is re-used

The opposite order of login activities (first SSO, later LDAP) failed with the following error message:

> [ERROR] seahub.base.accounts:1004 authenticate ldap user 123...789@auth.local not found.

The introduction of SSO_LDAP_USE_SAME_UID lacked the fallback procedure from LDAP to SSO.
This commit fixes that issue.