### PR TITLE
clean image preview cache after rotate

### DIFF
--- a/frontend/src/components/dir-view-mode/dir-files.js
+++ b/frontend/src/components/dir-view-mode/dir-files.js
@@ -61,6 +61,7 @@ class DirFiles extends React.Component {
     this.isNodeMenuShow = true;
     this.imageItemsSnapshot = [];
     this.imageIndexSnapshot = 0;
+    this.rotateImageCacheBuster = new Date().getTime();
   }
 
   componentDidUpdate(prevProps) {
@@ -252,9 +253,9 @@ class DirFiles extends React.Component {
       const src = `${siteRoot}repo/${repoID}/raw${path}`;
       let thumbnail = '';
       if (repoEncrypted || isGIF) {
-        thumbnail = src;
+        thumbnail = `${src}?t=${this.rotateImageCacheBuster}`;
       } else {
-        thumbnail = `${siteRoot}thumbnail/${repoID}/${thumbnailSizeForOriginal}${path}`;
+        thumbnail = `${siteRoot}thumbnail/${repoID}/${thumbnailSizeForOriginal}${path}?t=${this.rotateImageCacheBuster}`;
       }
       return {
         name,
@@ -325,11 +326,11 @@ class DirFiles extends React.Component {
       imageAPI.rotateImage(repoID, path, 360 - angle).then((res) => {
         seafileAPI.createThumbnail(repoID, path, thumbnailDefaultSize).then((res) => {
           // Generate a unique query parameter to bust the cache
-          const cacheBuster = new Date().getTime();
-          const newThumbnailSrc = `${res.data.encoded_thumbnail_src}?t=${cacheBuster}`;
+          this.rotateImageCacheBuster = new Date().getTime();
+          const newThumbnailSrc = `${res.data.encoded_thumbnail_src}?t=${this.rotateImageCacheBuster}`;
           this.setState((prevState) => {
             const updatedImageItems = [...prevState.imageNodeItems];
-            updatedImageItems[imageIndex].src = newThumbnailSrc;
+            updatedImageItems[imageIndex].thumbnail = newThumbnailSrc;
             return { imageNodeItems: updatedImageItems };
           });
           // Update the thumbnail URL with the cache-busting query parameter

--- a/frontend/src/components/dirent-grid-view/dirent-grid-view.js
+++ b/frontend/src/components/dirent-grid-view/dirent-grid-view.js
@@ -102,6 +102,7 @@ class DirentGridView extends React.Component {
     };
     this.containerRef = React.createRef();
     this.isRepoOwner = props.currentRepoInfo.owner_email === username;
+    this.rotateImageCacheBuster = new Date().getTime();
   }
 
   componentDidMount() {
@@ -604,9 +605,9 @@ class DirentGridView extends React.Component {
     let thumbnail = '';
     const isGIF = fileExt === 'gif';
     if (repoEncrypted || isGIF) {
-      thumbnail = `${siteRoot}repo/${repoID}/raw${path}?t=${cacheBuster}`;
+      thumbnail = `${siteRoot}repo/${repoID}/raw${path}?t=${cacheBuster}?t=${this.rotateImageCacheBuster}`;
     } else {
-      thumbnail = `${siteRoot}thumbnail/${repoID}/${thumbnailSizeForOriginal}${path}`;
+      thumbnail = `${siteRoot}thumbnail/${repoID}/${thumbnailSizeForOriginal}${path}?t=${this.rotateImageCacheBuster}`;
     }
 
     let src = '';
@@ -684,11 +685,11 @@ class DirentGridView extends React.Component {
       imageAPI.rotateImage(repoID, path, 360 - angle).then((res) => {
         seafileAPI.createThumbnail(repoID, path, thumbnailDefaultSize).then((res) => {
           // Generate a unique query parameter to bust the cache
-          const cacheBuster = new Date().getTime();
-          const newThumbnailSrc = `${res.data.encoded_thumbnail_src}?t=${cacheBuster}`;
+          this.rotateImageCacheBuster = new Date().getTime();
+          const newThumbnailSrc = `${res.data.encoded_thumbnail_src}?t=${this.rotateImageCacheBuster}`;
           this.setState((prevState) => {
             const updatedImageItems = [...prevState.imageItems];
-            updatedImageItems[imageIndex].src = newThumbnailSrc;
+            updatedImageItems[imageIndex].thumbnail = newThumbnailSrc;
             return { imageItems: updatedImageItems };
           });
           // Update the thumbnail URL with the cache-busting query parameter

--- a/frontend/src/components/dirent-list-view/dirent-list-view.js
+++ b/frontend/src/components/dirent-list-view/dirent-list-view.js
@@ -102,6 +102,7 @@ class DirentListView extends React.Component {
       const { modify } = customPermission.permission;
       this.canDrop = modify;
     }
+    this.rotateImageCacheBuster = new Date().getTime();
   }
 
   componentDidMount() {
@@ -191,9 +192,9 @@ class DirentListView extends React.Component {
     let thumbnail = '';
     const isGIF = fileExt === 'gif';
     if (repoEncrypted || isGIF) {
-      thumbnail = `${siteRoot}repo/${repoID}/raw${path}`;
+      thumbnail = `${siteRoot}repo/${repoID}/raw${path}?t=${this.rotateImageCacheBuster}`;
     } else {
-      thumbnail = `${siteRoot}thumbnail/${repoID}/${thumbnailSizeForOriginal}${path}`;
+      thumbnail = `${siteRoot}thumbnail/${repoID}/${thumbnailSizeForOriginal}${path}?t=${this.rotateImageCacheBuster}`;
     }
 
     let src = '';
@@ -271,11 +272,11 @@ class DirentListView extends React.Component {
       imageAPI.rotateImage(repoID, path, 360 - angle).then((res) => {
         seafileAPI.createThumbnail(repoID, path, thumbnailDefaultSize).then((res) => {
           // Generate a unique query parameter to bust the cache
-          const cacheBuster = new Date().getTime();
-          const newThumbnailSrc = `${res.data.encoded_thumbnail_src}?t=${cacheBuster}`;
+          this.rotateImageCacheBuster = new Date().getTime();
+          const newThumbnailSrc = `${res.data.encoded_thumbnail_src}?t=${this.rotateImageCacheBuster}`;
           this.setState((prevState) => {
             const updatedImageItems = [...prevState.imageItems];
-            updatedImageItems[imageIndex].src = newThumbnailSrc;
+            updatedImageItems[imageIndex].thumbnail = newThumbnailSrc;
             return { imageItems: updatedImageItems };
           });
           // Update the thumbnail URL with the cache-busting query parameter


### PR DESCRIPTION
After rotating the image, avoid using browser cache and load a new image from the server:
1. First loading: Before opening an image, we don't know if it has been rotated or if there is an old image cache locally, so we initialize it with a timestamp to ensure that the existing cache is cleared.
2. After rotating the image: reset the timestamp to ensure that the latest thumbnail is obtained.