### PR TITLE
['library folder permission' dialog] redesigned the 'add folder' panel

### DIFF
--- a/frontend/src/components/dialog/lib-sub-folder-set-group-permission-dialog.js
+++ b/frontend/src/components/dialog/lib-sub-folder-set-group-permission-dialog.js
@@ -279,18 +279,21 @@ class LibSubFolderSetGroupPermissionDialog extends React.Component {
 
     if (this.state.showFileChooser) {
       return (
-        <div>
+        <>
+          <div className="d-flex align-items-center justify-content-between pb-2 border-bottom">
+            <h6 className="font-weight-normal m-0">
+              <button className="sf3-font sf3-font-arrow rotate-180 d-inline-block back-icon border-0 bg-transparent text-secondary p-0 mr-2" onClick={this.toggleFileChooser} title={gettext('Back')} aria-label={gettext('Back')}></button>
+              {gettext('Add Folder')}
+            </h6>
+            <Button color="primary" size="sm" outline={true} onClick={this.handleSubmit}>{gettext('Submit')}</Button>
+          </div>
           <FileChooser
             repoID={this.props.repoID}
             mode={'only_current_library'}
             onDirentItemClick={this.toggleSubFolder}
             onRepoItemClick={this.onRepoItemClick}
           />
-          <div className="modal-footer">
-            <Button color="secondary" onClick={this.toggleFileChooser}>{gettext('Cancel')}</Button>
-            <Button color="primary" onClick={this.handleSubmit}>{gettext('Submit')}</Button>
-          </div>
-        </div>
+        </>
       );
     }
 

--- a/frontend/src/components/dialog/lib-sub-folder-set-user-permission-dialog.js
+++ b/frontend/src/components/dialog/lib-sub-folder-set-user-permission-dialog.js
@@ -242,18 +242,21 @@ class LibSubFolderSetUserPermissionDialog extends React.Component {
 
     if (this.state.showFileChooser) {
       return (
-        <div>
+        <>
+          <div className="d-flex align-items-center justify-content-between pb-2 border-bottom">
+            <h6 className="font-weight-normal m-0">
+              <button className="sf3-font sf3-font-arrow rotate-180 d-inline-block back-icon border-0 bg-transparent text-secondary p-0 mr-2" onClick={this.toggleFileChooser} title={gettext('Back')} aria-label={gettext('Back')}></button>
+              {gettext('Add Folder')}
+            </h6>
+            <Button color="primary" size="sm" outline={true} onClick={this.handleFileChooserSubmit}>{gettext('Submit')}</Button>
+          </div>
           <FileChooser
             repoID={this.props.repoID}
             mode={'only_current_library'}
             onDirentItemClick={this.toggleSubFolder}
             onRepoItemClick={this.onRepoItemClick}
           />
-          <div className="modal-footer">
-            <Button color="secondary" onClick={this.toggleFileChooser}>{gettext('Cancel')}</Button>
-            <Button color="primary" onClick={this.handleFileChooserSubmit}>{gettext('Submit')}</Button>
-          </div>
-        </div>
+        </>
       );
     }
 

--- a/frontend/src/components/file-chooser/index.js
+++ b/frontend/src/components/file-chooser/index.js
@@ -448,7 +448,7 @@ class FileChooser extends React.Component {
     return (
       <>
         {(isPro && mode !== 'recently_used') && (
-          <div className="file-chooser-search-input">
+          <div className="file-chooser-search-input py-4">
             <Input className="search-input" placeholder={gettext('Search')} type='text' value={searchInfo} onChange={this.onSearchInfoChanged}></Input>
             {searchInfo.length !== 0 && (
               <span className="search-control attr-action-icon sf3-font sf3-font-x-01" onClick={this.onCloseSearching}></span>


### PR DESCRIPTION
- added a title, a 'back' icon, and a 'submit' button to the top
- removed the 'cancel' & 'submit' buttons in the bottom
- added gaps above & below the search input