### PR TITLE
[dir view] 'move', 'copy' dialogs: fixed the split line of the left a…

### DIFF
--- a/frontend/src/components/dialog/select-dirent-body.js
+++ b/frontend/src/components/dialog/select-dirent-body.js
@@ -130,7 +130,7 @@ class SelectDirentBody extends React.Component {
 
     return (
       <Row>
-        <Col className='repo-list-col border-right'>
+        <Col className='repo-list-col border-end'>
           <LibraryOption
             mode={MODE_TYPE_MAP.ONLY_CURRENT_LIBRARY}
             label={gettext('Current Library')}


### PR DESCRIPTION
…nd right panels after the upgrade of seafile-ui.css