### PR TITLE
Fix improperly scoped variables when sending administrative reset of user password email

### DIFF
--- a/seahub/api2/endpoints/admin/users.py
+++ b/seahub/api2/endpoints/admin/users.py
@@ -1543,6 +1543,9 @@ class AdminUserResetPassword(APIView):
 
         if IS_EMAIL_CONFIGURED:
             if SEND_EMAIL_ON_RESETTING_USER_PASSWD:
+                from seahub.utils import get_site_name
+                from django.utils.http import int_to_base36
+                from seahub.auth.tokens import default_token_generator                
                 c = {'email': email, 'password': new_password}
                 contact_email = Profile.objects.get_contact_email_by_user(email)
                 try:


### PR DESCRIPTION
get_site_name() and similar are not properly in scope in this branch where they are used in the following try block, so this imports them properly in this branch as they are in the other branch where they are used.