### PR TITLE
Resolve Python Logger warnings

### DIFF
--- a/seahub/auth/views.py
+++ b/seahub/auth/views.py
@@ -138,7 +138,7 @@ def login(request, template_name='registration/login.html',
         if failed_attempt >= config.LOGIN_ATTEMPT_LIMIT:
             if bool(config.FREEZE_USER_ON_LOGIN_FAILED) is True:
                 # log user in if password is valid otherwise freeze account
-                logger.warn('Login attempt limit reached, try freeze the user, email/username: %s, ip: %s, attemps: %d' %
+                logger.warning('Login attempt limit reached, try freeze the user, email/username: %s, ip: %s, attempts: %d' %
                             (login, ip, failed_attempt))
                 email = Profile.objects.get_username_by_login_id(login)
                 if email is None:
@@ -149,16 +149,16 @@ def login(request, template_name='registration/login.html',
                     user = User.objects.get(email)
                     if user.is_active:
                         user.freeze_user(notify_admins=True, notify_org_admins=True)
-                        logger.warn('Login attempt limit reached, freeze the user email/username: %s, ip: %s, attemps: %d' %
+                        logger.warning('Login attempt limit reached, freeze the user email/username: %s, ip: %s, attempts: %d' %
                                     (login, ip, failed_attempt))
                 except User.DoesNotExist:
-                    logger.warn('Login attempt limit reached with invalid email/username: %s, ip: %s, attemps: %d' %
+                    logger.warning('Login attempt limit reached with invalid email/username: %s, ip: %s, attempts: %d' %
                                 (login, ip, failed_attempt))
                     pass
                 form.errors['freeze_account'] = _('This account has been frozen due to too many failed login attempts.')
             else:
                 # use a new form with Captcha
-                logger.warn('Login attempt limit reached, show Captcha, email/username: %s, ip: %s, attemps: %d' %
+                logger.warning('Login attempt limit reached, show Captcha, email/username: %s, ip: %s, attempts: %d' %
                             (login, ip, failed_attempt))
                 if not used_captcha_already:
                     form = CaptchaAuthenticationForm()
@@ -170,7 +170,7 @@ def login(request, template_name='registration/login.html',
             if bool(config.FREEZE_USER_ON_LOGIN_FAILED) is True:
                 form = authentication_form()
             else:
-                logger.warn('Login attempt limit reached, show Captcha, ip: %s, attempts: %d' %
+                logger.warning('Login attempt limit reached, show Captcha, ip: %s, attempts: %d' %
                             (ip, failed_attempt))
                 form = CaptchaAuthenticationForm()
         else:

--- a/seahub/base/models.py
+++ b/seahub/base/models.py
@@ -283,7 +283,7 @@ class UserLastLoginManager(models.Manager):
             ret = dups[0]
             for dup in dups[1:]:
                 dup.delete()
-                logger.warn('Delete duplicate user last login record: %s' % username)
+                logger.warning('Delete duplicate user last login record: %s' % username)
             return ret
 
 

--- a/seahub/profile/models.py
+++ b/seahub/profile/models.py
@@ -64,7 +64,7 @@ class ProfileManager(models.Manager):
             profile = self.get(user=username)
             profile.contact_email = contact_email
         except Profile.DoesNotExist:
-            logger.warn('%s profile does not exists' % username)
+            logger.warning('%s profile does not exists' % username)
             return None
 
         try:
@@ -207,7 +207,7 @@ class DetailedProfileManager(models.Manager):
         else:
             # XXX: got multiple records, delete them all.
             super(DetailedProfileManager, self).filter(user=username).delete()
-            logger.warn('Remove multiple detailed profile records for user %s' % username)
+            logger.warning('Remove multiple detailed profile records for user %s' % username)
             return None
 
 class DetailedProfile(models.Model):

--- a/seahub/role_permissions/settings.py
+++ b/seahub/role_permissions/settings.py
@@ -147,7 +147,7 @@ def get_enabled_admin_role_permissions():
         default_admin_permissions = DEFAULT_ENABLED_ADMIN_ROLE_PERMISSIONS[DEFAULT_ADMIN]
         for k in list(perms.keys()):
             if k not in list(default_admin_permissions.keys()):
-                logger.warn('"%s" is not valid permission, please review the ENABLED_ADMIN_ROLE_PERMISSIONS setting.' % k)
+                logger.warning('"%s" is not valid permission, please review the ENABLED_ADMIN_ROLE_PERMISSIONS setting.' % k)
 
         all_false_permission = {}
         for permission in list(default_admin_permissions.keys()):

--- a/seahub/role_permissions/utils.py
+++ b/seahub/role_permissions/utils.py
@@ -21,7 +21,7 @@ def get_enabled_role_permissions_by_role(role=DEFAULT_USER):
         role = DEFAULT_USER
     
     if role not in list(ENABLED_ROLE_PERMISSIONS.keys()):
-        logger.warn('%s is not a valid role, use default role.' % role)
+        logger.warning('%s is not a valid role, use default role.' % role)
         role = DEFAULT_USER
 
     return ENABLED_ROLE_PERMISSIONS[role]
@@ -41,7 +41,7 @@ def get_enabled_admin_role_permissions_by_role(role):
         role = DEFAULT_ADMIN
 
     if role not in list(ENABLED_ADMIN_ROLE_PERMISSIONS.keys()):
-        logger.warn('%s is not a valid admin role, use audit admin role.' % role)
+        logger.warning('%s is not a valid admin role, use audit admin role.' % role)
         role = AUDIT_ADMIN
 
     return ENABLED_ADMIN_ROLE_PERMISSIONS[role]

--- a/seahub/share/models.py
+++ b/seahub/share/models.py
@@ -57,7 +57,7 @@ def set_share_link_access(request, token, is_upload_link=False):
         request.session[link_key] = True
     else:
         # should never reach here in normal case
-        logger.warn('Failed to remember shared link password, request.session'
+        logger.warning('Failed to remember shared link password, request.session'
                     ' is None when set shared link access.')
 
 

--- a/seahub/utils/licenseparse.py
+++ b/seahub/utils/licenseparse.py
@@ -37,7 +37,7 @@ def parse_license():
         with open(get_license_path(), encoding='utf-8') as f:
             lines = f.readlines()
     except Exception as e:
-        logger.warn(e)
+        logger.warning(e)
         return {}
 
     for line in lines:

--- a/seahub/utils/rpc.py
+++ b/seahub/utils/rpc.py
@@ -31,7 +31,7 @@ class RPCProxy(object):
             try:
                 return real_func(*args, **kwargs)
             except SearpcError as e:
-                logger.warn(e, exc_info=True)
+                logger.warning(e, exc_info=True)
                 return None
         else:
             return real_func(*args, **kwargs)

--- a/seahub/utils/star.py
+++ b/seahub/utils/star.py
@@ -23,7 +23,7 @@ def star_file(email, repo_id, path, is_dir, org_id=-1):
     try:
         f.save()
     except IntegrityError as e:
-        logger.warn(e)
+        logger.warning(e)
 
 def unstar_file(email, repo_id, path):
     # Should use "get", but here we use "filter" to fix the bug caused by no

--- a/seahub/views/__init__.py
+++ b/seahub/views/__init__.py
@@ -97,7 +97,7 @@ def validate_owner(request, repo_id):
 
 def is_registered_user(email):
     """
-    Check whether user is registerd.
+    Check whether user is registered.
 
     """
     try:
@@ -193,7 +193,7 @@ def get_repo_dirents(request, repo, commit, path, offset=-1, limit=-1):
     """List repo dirents based on commit id and path. Use ``offset`` and
     ``limit`` to do paginating.
 
-    Returns: A tupple of (file_list, dir_list, dirent_more)
+    Returns: A tuple of (file_list, dir_list, dirent_more)
 
     TODO: Some unrelated parts(file sharing, stars, modified info, etc) need
     to be pulled out to multiple functions.
@@ -737,7 +737,7 @@ def demo(request):
     try:
         user = User.objects.get(email=settings.CLOUD_DEMO_USER)
     except User.DoesNotExist:
-        logger.warn('CLOUD_DEMO_USER: %s does not exist.' % settings.CLOUD_DEMO_USER)
+        logger.warning('CLOUD_DEMO_USER: %s does not exist.' % settings.CLOUD_DEMO_USER)
         raise Http404
 
     for backend in get_backends():

--- a/seahub/views/file.py
+++ b/seahub/views/file.py
@@ -666,7 +666,7 @@ def view_lib_file(request, repo_id, path):
     return_dict['latest_contributor'] = latest_contributor
     return_dict['last_modified'] = last_modified
 
-    # get file type and extention
+    # get file type and extension
     filetype, fileext = get_file_type_and_ext(filename)
     return_dict['fileext'] = fileext
     return_dict['filetype'] = filetype
@@ -684,7 +684,7 @@ def view_lib_file(request, repo_id, path):
         raw_path = gen_file_get_url(token, filename)
         inner_path = gen_inner_file_get_url(token, filename)
 
-    # handle file preview/edit according to file extention
+    # handle file preview/edit according to file extension
     file_size = seafile_api.get_file_size(repo.store_id, repo.version, file_id)
     # template = 'view_file_%s.html' % filetype.lower()
     template = '%s_file_view_react.html' % filetype.lower()
@@ -1000,7 +1000,7 @@ def view_history_file_common(request, repo_id, ret_dict):
     if not obj_id:
         raise Http404
 
-    # construct some varibles
+    # construct some variables
     u_filename = os.path.basename(path)
     current_commit = get_commit(repo.id, repo.version, commit_id)
     if not current_commit:
@@ -1753,7 +1753,7 @@ def view_raw_file(request, repo_id, file_path):
     return HttpResponseRedirect(raw_path)
 
 def send_file_access_msg(request, repo, path, access_from, custom_ip=None, custom_agent=None):
-    """Send file downlaod msg for audit.
+    """Send file download msg for audit.
 
     Arguments:
     - `request`:
@@ -1763,7 +1763,7 @@ def send_file_access_msg(request, repo, path, access_from, custom_ip=None, custo
     """
     access_from = access_from.lower()
     if access_from not in ['web', 'api', 'share-link']:
-        logger.warn('Invalid access_from in file access msg: %s' % access_from)
+        logger.warning('Invalid access_from in file access msg: %s' % access_from)
         return
 
     username = request.user.username


### PR DESCRIPTION
# PR Summary
This PR resolves the deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```
It also fixes a few typos along the way.