### PR TITLE
Fix: Allow preview and edit of native Excalidraw and TLDraw files

### DIFF
--- a/frontend/src/utils/utils.js
+++ b/frontend/src/utils/utils.js
@@ -114,7 +114,9 @@ export const Utils = {
     'webp': 'pic.png',
     'jfif': 'pic.png',
     'draw': 'draw.png',
+    'tldr': 'draw.png',
     'exdraw': 'draw.png',
+    'excalidraw': 'draw.png',
 
     // photoshop file
     'psd': 'psd.png',
@@ -245,11 +247,11 @@ export const Utils = {
     }
     const file_ext = filename.substr(filename.lastIndexOf('.') + 1).toLowerCase();
 
-    if (enableSeadoc && file_ext == 'exdraw') {
-      return true;
-    } else {
-      return false;
+    if (enableSeadoc) {
+      return ['exdraw', 'excalidraw'].includes(file_ext);
     }
+
+    return false;
   },
 
   // check if a file is a video

--- a/seahub/base/templatetags/seahub_tags.py
+++ b/seahub/base/templatetags/seahub_tags.py
@@ -106,7 +106,9 @@ FILEEXT_ICON_MAP = {
     'ico': 'pic.png',
     'psd': 'psd.png',
     'draw': 'draw.png',
+    'tldr': 'draw.png',
     'exdraw': 'draw.png',
+    'excalidraw': 'draw.png',
 
     # zip file
     'zip': 'zip.png',

--- a/seahub/settings.py
+++ b/seahub/settings.py
@@ -1078,7 +1078,7 @@ METADATA_FILE_TYPES = {
                'm4v', 'mkv', 'flv', 'vob'),
     '_audio': ('mp3', 'oga', 'ogg', 'wav', 'flac', 'opus', 'aac', 'au', 'm4a', 'aif', 'aiff', 'wma', 'mp1', 'mp2'),
     '_compressed': ('rar', 'zip', '7z', 'tar', 'gz', 'bz2', 'tgz', 'xz', 'lzma'),
-    '_diagram': ('draw', 'exdraw'),
+    '_diagram': ('draw', 'tldr', 'exdraw', 'excalidraw'),
 }
 
 ##############################

--- a/seahub/utils/__init__.py
+++ b/seahub/utils/__init__.py
@@ -125,8 +125,8 @@ PREVIEW_FILEEXT = {
     AUDIO: ('mp3', 'oga', 'ogg', 'wav', 'flac', 'opus'),
     #'3D': ('stl', 'obj'),
     SEADOC: ('sdoc',),
-    TLDRAW: ('draw',),
-    EXCALIDRAW: ('exdraw',),
+    TLDRAW: ('draw','tldr'),
+    EXCALIDRAW: ('exdraw','excalidraw'),
 }
 
 def get_non_sdoc_file_exts():


### PR DESCRIPTION
Excalidraw files are currently non-portable because seafile is using the `.exdraw` file extension.  The same thing is true with TLDraw files.

According to the [Excalidraw docs](https://docs.excalidraw.com/docs/codebase/json-schema#excalidraw-files), the file extension should be `.excalidraw`:

<img width="820" height="261" alt="image" src="https://github.com/user-attachments/assets/99c1ae28-5fc0-446a-92b9-1c8f5eda96a2" />

Similarly, TLDraw files typically use the `.tldr` extension.

This PR enables interoperability and use of _both_ the native extensions and seafile-specific extensions without any breaking changes.