### PR TITLE
Improve table header layout in shared libs page

### DIFF
--- a/frontend/src/pages/shared-libs/content.js
+++ b/frontend/src/pages/shared-libs/content.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { gettext } from '../../utils/constants';
@@ -120,11 +120,27 @@ class Content extends Component {
             <thead>
               <tr>
                 <th width="4%"></th>
-                <th width="3%"><span className="sr-only">{gettext('Library Type')}</span></th>
-                <th width="35%"><a className="d-block table-sort-op" href="#" onClick={this.sortByName}>{gettext('Name')} {sortByName && sortIcon}</a></th>
-                <th width="10%"><span className="sr-only">{gettext('Actions')}</span></th>
-                <th width="14%"><a className="d-block table-sort-op" href="#" onClick={this.sortBySize}>{gettext('Size')} {sortBySize && sortIcon}</a></th>
-                <th width="17%"><a className="d-block table-sort-op" href="#" onClick={this.sortByTime}>{gettext('Last Update')} {sortByTime && sortIcon}</a></th>
+                <th width="3%">
+                  <span className="sr-only">{gettext('Library Type')}</span>
+                </th>
+                <th width="35%">
+                  <a className="d-flex align-items-center table-sort-op" href="#" onClick={this.sortByName}>
+                    {gettext('Name')} {sortByName && sortIcon}
+                  </a>
+                </th>
+                <th width="10%">
+                  <span className="sr-only">{gettext('Actions')}</span>
+                </th>
+                <th width="14%">
+                  <a className="d-flex align-items-center table-sort-op" href="#" onClick={this.sortBySize}>
+                    {gettext('Size')} {sortBySize && sortIcon}
+                  </a>
+                </th>
+                <th width="17%">
+                  <a className="d-flex align-items-center table-sort-op" href="#" onClick={this.sortByTime}>
+                    {gettext('Last Update')} {sortByTime && sortIcon}
+                  </a>
+                </th>
                 <th width="17%">{gettext('Owner')}</th>
               </tr>
             </thead>


### PR DESCRIPTION
Refactored table header cells to use multi-line formatting and applied 'd-flex align-items-center' classes to sortable columns for better alignment and visual consistency.