### PR TITLE
Remove redundant indexes from mysql.sql

### DIFF
--- a/seahub/base/models.py
+++ b/seahub/base/models.py
@@ -310,7 +310,7 @@ def update_last_login(sender, user, **kwargs):
 user_logged_in.connect(update_last_login)
 
 class OrgLastActivityTime(models.Model):
-    org_id = models.IntegerField(unique=True, db_index=True)
+    org_id = models.IntegerField(unique=True)
     timestamp = models.DateTimeField(default=timezone.now)
 
     class Meta:
@@ -404,7 +404,7 @@ class RepoSecretKey(models.Model):
 class UserMonitoredRepos(models.Model):
     """
     """
-    email = models.EmailField(db_index=True)
+    email = models.EmailField()
     repo_id = models.CharField(max_length=36, db_index=True)
     timestamp = models.DateTimeField(default=timezone.now)
 
@@ -625,7 +625,7 @@ class FileTrash(models.Model):
     obj_id = models.CharField(max_length=40)
     obj_name = models.CharField(max_length=255)
     delete_time = models.DateTimeField()
-    repo_id = models.CharField(max_length=36, db_index=True)
+    repo_id = models.CharField(max_length=36)
     commit_id = models.CharField(max_length=40)
     path = models.TextField()
     size = models.BigIntegerField()

--- a/seahub/onlyoffice/models.py
+++ b/seahub/onlyoffice/models.py
@@ -19,7 +19,7 @@ class OnlyOfficeDocKey(models.Model):
 REPO_OFFICE_CONFIG = 'office'
 class RepoExtraConfig(models.Model):
 
-    repo_id = models.CharField(max_length=36, db_index=True)
+    repo_id = models.CharField(max_length=36)
     config_type = models.CharField(max_length=50)
     config_details = models.TextField()
 

--- a/seahub/organizations/models.py
+++ b/seahub/organizations/models.py
@@ -219,7 +219,7 @@ class OrgAdminSettings(models.Model):
     # boolean settings / str settings / int settings, etc
     # key: default-value
 
-    org_id = models.IntegerField(db_index=True, null=False)
+    org_id = models.IntegerField(null=False)
     key = models.CharField(max_length=255, null=False)
     value = models.TextField()
 

--- a/seahub/repo_metadata/models.py
+++ b/seahub/repo_metadata/models.py
@@ -64,7 +64,7 @@ class RepoMetadata(models.Model):
     created_time = models.DateTimeField(auto_now_add=True)
     modified_time = models.DateTimeField(auto_now=True)
     enabled = models.BooleanField(db_index=True)
-    face_recognition_enabled = models.BooleanField(db_index=True)
+    face_recognition_enabled = models.BooleanField()
     from_commit = models.CharField(max_length=40)
     to_commit = models.CharField(max_length=40)
     tags_enabled = models.BooleanField(db_index=True)

--- a/seahub/seadoc/models.py
+++ b/seahub/seadoc/models.py
@@ -21,7 +21,7 @@ class SeadocHistoryNameManager(models.Manager):
 
 
 class SeadocHistoryName(models.Model):
-    doc_uuid = models.CharField(max_length=36, db_index=True)
+    doc_uuid = models.CharField(max_length=36)
     obj_id = models.CharField(max_length=40)
     name = models.CharField(max_length=255)
 
@@ -145,7 +145,7 @@ class SeadocRevision(models.Model):
     """
     doc_uuid = models.CharField(max_length=36, unique=True)
     origin_doc_uuid = models.CharField(max_length=36, db_index=True)
-    repo_id = models.CharField(max_length=36, db_index=True)
+    repo_id = models.CharField(max_length=36)
     revision_id = models.IntegerField()  # revision_id in repo
     origin_doc_path = models.TextField()  # used when origin file deleted
     username = models.CharField(max_length=255, db_index=True)

--- a/seahub/share/models.py
+++ b/seahub/share/models.py
@@ -377,10 +377,10 @@ class FileShare(models.Model):
     token = models.CharField(max_length=100, unique=True)
     ctime = models.DateTimeField(default=datetime.datetime.now)
     view_cnt = models.IntegerField(default=0)
-    s_type = models.CharField(max_length=2, db_index=True, default='f')  # `f` or `d`
+    s_type = models.CharField(max_length=2, default='f')  # `f` or `d`
     password = models.CharField(max_length=128, null=True)
     expire_date = models.DateTimeField(null=True)
-    permission = models.CharField(max_length=50, db_index=True,
+    permission = models.CharField(max_length=50,
                                   choices=PERMISSION_CHOICES,
                                   default=PERM_VIEW_DL)
 

--- a/seahub/wiki2/models.py
+++ b/seahub/wiki2/models.py
@@ -89,7 +89,7 @@ class WikiPageTrash(models.Model):
         }
 
 class Wiki2Publish(models.Model):
-    repo_id = models.CharField(max_length=36, unique=True, db_index=True)
+    repo_id = models.CharField(max_length=36, unique=True)
     publish_url = models.CharField(max_length=40, null=True, unique=True)
     username = models.CharField(max_length=255)
     created_at = models.DateTimeField(auto_now_add=True)

--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -955,8 +955,6 @@ CREATE TABLE `share_fileshare` (
   UNIQUE KEY `token` (`token`),
   KEY `share_fileshare_username_5cb6de75` (`username`),
   KEY `share_fileshare_repo_id_9b5ae27a` (`repo_id`),
-  KEY `share_fileshare_s_type_724eb6c1` (`s_type`),
-  KEY `share_fileshare_permission_d12c353f` (`permission`),
   KEY `idx_ctime` (`ctime`),
   KEY `idx_view_cnt` (`view_cnt`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -1373,7 +1371,6 @@ CREATE TABLE `base_usermonitoredrepos` (
   `timestamp` datetime(6) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `base_usermonitoredrepos_email_repo_id_b4ab00e4_uniq` (`email`,`repo_id`),
-  KEY `base_usermonitoredrepos_email_55ead1b9` (`email`),
   KEY `base_usermonitoredrepos_repo_id_00e624c3` (`repo_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
@@ -1383,8 +1380,7 @@ CREATE TABLE `organizations_orgadminsettings` (
   `key` varchar(255) NOT NULL,
   `value` longtext NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `organizations_orgadminsettings_org_id_key_a01cc7de_uniq` (`org_id`,`key`),
-  KEY `organizations_orgadminsettings_org_id_4f70d186` (`org_id`)
+  UNIQUE KEY `organizations_orgadminsettings_org_id_key_a01cc7de_uniq` (`org_id`,`key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `history_name` (
@@ -1393,7 +1389,6 @@ CREATE TABLE `history_name` (
   `obj_id` varchar(40) NOT NULL,
   `name` varchar(255) NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `history_name_doc_uuid` (`doc_uuid`),
   UNIQUE KEY `history_name_doc_uuid_obj_id` (`doc_uuid`, `obj_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -1426,7 +1421,6 @@ CREATE TABLE `sdoc_revision` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `sdoc_revision_doc_uuid` (`doc_uuid`),
   UNIQUE KEY `sdoc_revision_repo_id_revision_id` (`repo_id`, `revision_id`),
-  KEY `sdoc_revision_repo_id` (`repo_id`),
   KEY `sdoc_revision_origin_doc_uuid` (`origin_doc_uuid`),
   KEY `sdoc_revision_username` (`username`),
   KEY `sdoc_revision_is_published` (`is_published`)
@@ -1499,7 +1493,7 @@ CREATE TABLE `FileTrash` (
   `path` text NOT NULL,
   `size` bigint(20) NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `ix_FileTrash_repo_id` (`repo_id`)
+  KEY `idx_filetrash_repo_delete_time` (`repo_id`, `delete_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 CREATE TABLE `WikiPageTrash` (
@@ -1545,7 +1539,6 @@ CREATE TABLE `repo_metadata`  (
   `global_hidden_columns` longtext DEFAULT NULL,
   UNIQUE KEY `key_repo_metadata_repo_id`(`repo_id`),
   KEY `key_repo_metadata_enabled`(`enabled`),
-  KEY `key_repo_metadata_face_recognition_enabled`(`face_recognition_enabled`),
   KEY `key_last_face_cluster_time_face_recognition_enabled` (`face_recognition_enabled`,`last_face_cluster_time`),
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
@@ -1567,7 +1560,6 @@ CREATE TABLE `sdoc_operation_log` (
   `author` varchar(255) NOT NULL,
   PRIMARY KEY (`id`),
   KEY `sdoc_operation_log_op_time` (`op_time`),
-  KEY `sdoc_operation_log_doc_uuid` (`doc_uuid`),
   KEY `sdoc_idx_operation_log_doc_uuid_op_id` (`doc_uuid`,`op_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -1580,8 +1572,7 @@ CREATE TABLE `wiki_wiki2_publish` (
   `visit_count` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `repo_id` (`repo_id`),
-  UNIQUE KEY `publish_url` (`publish_url`),
-  KEY `ix_wiki2_publish_repo_id` (`repo_id`)
+  UNIQUE KEY `publish_url` (`publish_url`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 CREATE TABLE `RepoTransfer` (
@@ -1614,7 +1605,6 @@ CREATE TABLE `repo_extra_config` (
   `config_type` varchar(50) NOT NULL,
   `config_details` longtext DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `ix_repo_extra_repo_id` (`repo_id`),
   UNIQUE KEY `ix_repo_extra_repo_idconfig_type` (`repo_id`, `config_type`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
@@ -1623,9 +1613,8 @@ CREATE TABLE `org_last_active_time` (
   `org_id` int(11) NOT NULL,
   `timestamp` datetime(6) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `org_id` (`org_id`),
-  KEY `ix_org_last_active_time_org_id` (`org_id`)
-  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+  UNIQUE KEY `org_id` (`org_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 CREATE TABLE `group_member_audit` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1666,8 +1655,7 @@ CREATE TABLE `stats_ai_by_team` (
   `created_at` datetime(6) DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `stats_ai_by_team_org_id_month_model` (`org_id`,`month`,`model`),
-  KEY `ix_stats_ai_by_team_org_id_month` (`org_id`,`month`)
+  UNIQUE KEY `stats_ai_by_team_org_id_month_model` (`org_id`,`month`,`model`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 CREATE TABLE `stats_ai_by_owner` (
@@ -1681,8 +1669,7 @@ CREATE TABLE `stats_ai_by_owner` (
   `created_at` datetime(6) DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `stats_ai_by_owner_username_month_model` (`username`,`month`,`model`),
-  KEY `ix_stats_ai_by_owner_username_month` (`username`,`month`)
+  UNIQUE KEY `stats_ai_by_owner_username_month_model` (`username`,`month`,`model`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 CREATE TABLE `wiki_settings` (

--- a/sql/mysql.sql
+++ b/sql/mysql.sql
@@ -1493,7 +1493,8 @@ CREATE TABLE `FileTrash` (
   `path` text NOT NULL,
   `size` bigint(20) NOT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_filetrash_repo_delete_time` (`repo_id`, `delete_time`)
+  KEY `idx_filetrash_repo_delete_time` (`repo_id`, `delete_time`),
+  KEY `idx_fileTrash_delete_time` (`delete_time`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 CREATE TABLE `WikiPageTrash` (


### PR DESCRIPTION
Remove redundant indexes from upgrade script

Remove 11 redundant indexes (7 original + 4 newly discovered)

Add 4 newly discovered redundant indexes to upgrade script

Remove redundant db_index from SeadocHistoryName.doc_uuid and SeadocRevision.repo_id

Remove redundant db_index from Wiki2Publish.repo_id (unique already creates index)

Remove redundant db_index from OrgLastActivityTime.org_id and UserMonitoredRepos.email

Remove redundant db_index from RepoExtraConfig.repo_id

Remove redundant db_index from OrgAdminSettings.org_id

Remove redundant db_index from RepoMetadata.face_recognition_enabled

Add DROP INDEX for FileAudit redundant indexes in upgrade script

Add DROP INDEX for s_type and permission on share_fileshare in upgrade script

Remove db_index from FileShare.s_type and FileShare.permission

Remove s_type and permission indexes from share_fileshare in mysql.sql

Remove redundant db_index on FileTrash.repo_id (covered by composite index)

Remove ix_FileTrash_repo_id from mysql.sql schema

Add DROP INDEX for ix_FileTrash_repo_id in upgrade script

Replace ix_FileTrash_repo_id with composite index (repo_id, delete_time) in mysql.sql

Add CREATE INDEX for composite index in upgrade script