### PR TITLE
Top bar: Fix unfold invisible button

### DIFF
--- a/frontend/src/css/file-view.css
+++ b/frontend/src/css/file-view.css
@@ -35,20 +35,20 @@ body {
 #unfold-onlyoffice-file-view-header {
   position: absolute;
   top: 0;
-  right: 40px;
+  right: 140px;
   width: 28px;
   height: 28px;
   display: flex;
   justify-content: center;
   align-items: center;
-  background: rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.6) !important;
   border-radius: 0 0 14px 14px;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.4);
   cursor: pointer;
 }
 
 #unfold-onlyoffice-file-view-header:hover {
-  background: rgba(255, 255, 255, 1);
+  background: rgba(255, 255, 255, 1) !important;
 }
 
 .file-view-header .file-toolbar-btn {


### PR DESCRIPTION
Before this commit, the unfold button that appears after folding the
Seafile's top bar was being rendered without background making it very
difficult to see and interact with.

This is due to the icon-button.js and the specific "bg-transparent"
class that is set to all icons.

Signed-off-by: Pedro Pinto Silva <pedro.silva@collabora.com>

----

Before:

<img width="195" height="94" alt="seafile-fold-btn" src="https://github.com/user-attachments/assets/d2d9f84f-1614-4cd1-9332-a3640f0ebe18" />
<img width="195" height="94" alt="seafile-unfold-transparent" src="https://github.com/user-attachments/assets/6fc4c6e7-6920-4686-ad6a-c095aff5f1c9" />



----

After:

<img width="1920" height="1047" alt="seafile-unfold-fixed-screenshot" src="https://github.com/user-attachments/assets/338afc50-6b2b-40c6-8905-04548899f686" />
