### PR TITLE
[dir trash view] fixup: don't display the top left 'selected' toolbar…

### DIFF
--- a/frontend/src/components/dir-view-mode/dir-trash-view/index.js
+++ b/frontend/src/components/dir-view-mode/dir-trash-view/index.js
@@ -102,11 +102,18 @@ export default function DirTrashView({ repoID, toggleShowDirentToolbar }) {
       });
       setTrashList(newTrashList);
       toaster.success(gettext('Restored 1 item'));
+
+      // at present, when right click a cell, the row it belongs to is selected.
+      setSelectIds([]);
+      const eventBus = EventBus.getInstance();
+      eventBus.dispatch(EVENT_BUS_TYPE.SELECT_TRASH, []);
+      eventBus.dispatch(EVENT_BUS_TYPE.SELECT_NONE, []);
+      toggleShowDirentToolbar(false);
     }).catch(error => {
       const errorMessage = Utils.getErrorMsg(error);
       toaster.danger(errorMessage);
     });
-  }, [repoID, trashList]);
+  }, [repoID, trashList, toggleShowDirentToolbar]);
 
   const onTrashSearchValueChange = useCallback((value) => {
     if (!value && !isFiltersValid(trashFilters)) {


### PR DESCRIPTION
… after clicking the 'restore file/folder' option in the context menu of a cell