### PR TITLE
Add REDIS_DB env var for cache db selection

### DIFF
--- a/seahub/settings.py
+++ b/seahub/settings.py
@@ -1268,8 +1268,9 @@ if CACHE_PROVIDER =='redis':
     redis_host = os.environ.get('REDIS_HOST') or cfg_redis_host
     redis_port = os.environ.get('REDIS_PORT') or cfg_redis_port
     redis_pwd = os.environ.get('REDIS_PASSWORD') or cfg_redis_pwd
+    redis_db = os.environ.get('REDIS_DB', '')
 
-    CACHES['default']['LOCATION'] = f'redis://{(":" + redis_pwd + "@") if redis_pwd else ""}{redis_host}:{redis_port}'
+    CACHES['default']['LOCATION'] = f'redis://{(":" + redis_pwd + "@") if redis_pwd else ""}{redis_host}:{redis_port}{("/" + redis_db) if redis_db else ""}'
     if redis_pwd:
         try:
             del CACHES['default']['OPTIONS']['PASSWORD']


### PR DESCRIPTION
Allows seahub's redis cache to connect to a non-zero Redis DB index.
Use case: shared Redis instance with other things.

Default behavior is unchanged. When `REDIS_DB` is unset (or empty), the constructed URL is identical to the one before this change, and redis-py falls back to db 0.

Tested locally: REDIS_DB=2 produces LOCATION = 'redis://redis:6379/2'. 