### PR TITLE
fix: revert permission check should target file/dir path, not library root

### DIFF
--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -3563,7 +3563,8 @@ class FileRevert(APIView):
             error_msg = 'file %s not found.' % path
             return api_error(status.HTTP_404_NOT_FOUND, error_msg)
 
-        if check_folder_permission(request, repo_id, '/') != 'rw':
+        parent_dir = os.path.dirname(path)
+        if check_folder_permission(request, repo_id, parent_dir) != 'rw':
             error_msg = 'Permission denied.'
             return api_error(status.HTTP_403_FORBIDDEN, error_msg)
 
@@ -4086,7 +4087,7 @@ class DirRevert(APIView):
             error_msg = 'folder %s not found.' % path
             return api_error(status.HTTP_404_NOT_FOUND, error_msg)
 
-        if check_folder_permission(request, repo_id, '/') != 'rw':
+        if check_folder_permission(request, repo_id, path) != 'rw':
             error_msg = 'Permission denied.'
             return api_error(status.HTTP_403_FORBIDDEN, error_msg)
 


### PR DESCRIPTION
FileRevert.put and DirRevert.put hard-code the permission check to the library root (`check_folder_permission(request, repo_id, '/')`). A user shared into a sub-folder with `rw` (no library-level `rw`-access) is incorrectly denied revert on files and directories they otherwise have full write access to, while every sibling write operation in FileView and DirView checks the file/dir's own location.

- FileRevert.put now checks the file's parent_dir, matching FileView.delete.
- DirRevert.put now checks the directory path itself, matching DirView.delete.

check_folder_permission resolves inherited share permissions downward, so a user with `rw` on `/Shared/ProjectA/` is correctly granted access for any descendant, while a user with no library or relevant folder share still gets denied — the only behavior change is that folder-rw shares grant revert as they grant every other write operation.