### PR TITLE
fix: allow Unicode characters in share link passwords

### DIFF
--- a/seahub/utils/__init__.py
+++ b/seahub/utils/__init__.py
@@ -1399,8 +1399,10 @@ ASCII_RE = re.compile(r'[^\x00-\x7f]')
 
 
 def is_valid_password(password):
-
-    return False if ASCII_RE.search(password) else True
+    """Check if password contains only printable characters (any Unicode)."""
+    # Allow any printable or whitespace character, reject control chars only
+    CONTROL_RE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]')
+    return False if CONTROL_RE.search(password) else True
 
 
 def get_logo_path_by_user(username):


### PR DESCRIPTION
﻿Fixes #8623

## Problem
Share link password validation rejected non-ASCII characters. Passwords with umlauts, diacritics, Greek, CJK etc. were blocked.

Root cause: is_valid_password() used ASCII_RE which rejects any char outside 0x00-0x7F.

## Fix
Replaced ASCII-only check with control-character check. Now allows all printable Unicode characters while still blocking invisible control chars (0x00-0x08, 0x0b-0x0c, 0x0e-0x1f, 0x7f).

File: seahub/utils/__init__.py

Password length and strength checks remain as additional security layers.

## Testing
Passwords with umlauts, French accents, Greek letters now accepted. Control chars still rejected.
