### PR TITLE
Improve context search error message

### DIFF
--- a/seahub/api2/endpoints/public_repos_search.py
+++ b/seahub/api2/endpoints/public_repos_search.py
@@ -32,7 +32,7 @@ class PublishedRepoSearchView(APIView):
     def get(self, request):
         # is search supported
         if not HAS_FILE_SEARCH and not HAS_FILE_SEASEARCH:
-            error_msg = 'Search not supported.'
+            error_msg = 'Search not supported in Seafile CE or is not enabled.'
             return api_error(status.HTTP_404_NOT_FOUND, error_msg)
 
         # argument check

--- a/seahub/api2/endpoints/wiki2.py
+++ b/seahub/api2/endpoints/wiki2.py
@@ -1464,7 +1464,7 @@ class WikiSearch(APIView):
 
     def post(self, request):
         if not HAS_FILE_SEARCH and not HAS_FILE_SEASEARCH:
-            error_msg = 'Search not supported.'
+            error_msg = 'Search not supported in Seafile CE or is not enabled.'
             return api_error(status.HTTP_404_NOT_FOUND, error_msg)
 
         query = request.data.get('query')

--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -463,7 +463,7 @@ class Search(APIView):
 
     def get(self, request, format=None):
         if not HAS_FILE_SEARCH and not HAS_FILE_SEASEARCH:
-            error_msg = 'Search not supported.'
+            error_msg = 'Search not supported in Seafile CE or is not enabled.'
             return api_error(status.HTTP_404_NOT_FOUND, error_msg)
 
         # argument check

--- a/seahub/seadoc/apis.py
+++ b/seahub/seadoc/apis.py
@@ -2996,7 +2996,7 @@ class SeadocSearchFilenameView(APIView):
         """Search sdoc by filename.
         """
         if not (HAS_FILE_SEARCH or HAS_FILE_SEASEARCH):
-            error_msg = 'Search not supported.'
+            error_msg = 'Search not supported in Seafile CE or is not enabled.'
             return api_error(status.HTTP_404_NOT_FOUND, error_msg)
 
         # argument check


### PR DESCRIPTION
This PR is related to a question in the Seafile forums (https://forum.seafile.com/t/search-in-wiki-not-supported/25133/2).
When someone wants to use the (context) search in Seafile CE, the current error message just shows "Search not supported". 

<img width="690" height="236" alt="image" src="https://github.com/user-attachments/assets/e4add060-8c81-4033-9ddf-04ce61a0cc52" />

It's not very clear why, especially for end users (non admins). 

With this PR I hope the understanding of the error message is better.