### PR TITLE
fix: upgrade immutable to 4.3.9, 5.1.8 (CVE-2026-59879)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "i18next-browser-languagedetector": "^8.1.0",
         "i18next-http-backend": "^3.0.2",
         "idb-keyval": "^6.2.2",
+        "immutable": "^4.3.9",
         "is-hotkey": "0.2.0",
         "is-url": "1.2.4",
         "js-cookie": "^3.0.7",
@@ -17469,9 +17470,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.9.tgz",
+      "integrity": "sha512-ObHy4YN7ycwZOUCLI1/6svfyAFu7vL8RhAvVu/bh/RZW9EPlOyDaQ9jDQWCtdqzaXUjgXZCW1migtHE7YI7UGQ==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "i18next-browser-languagedetector": "^8.1.0",
     "i18next-http-backend": "^3.0.2",
     "idb-keyval": "^6.2.2",
+    "immutable": "^4.3.9",
     "is-hotkey": "0.2.0",
     "is-url": "1.2.4",
     "js-cookie": "^3.0.7",


### PR DESCRIPTION
## Summary
Upgrade immutable from 4.3.8 to 4.3.9, 5.1.8 to fix CVE-2026-59879.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-59879 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-59879` |
| **File** | `frontend/package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: Immutable.js provides many Persistent Immutable data structures. Prior ...

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-59879` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `frontend/package.json`
- `frontend/package-lock.json`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
