### PR TITLE
Fix O(n^2) behaviour in recursive directory listing

### DIFF
--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -2275,7 +2275,7 @@ class UpdateBlksLinkView(APIView):
         url = gen_file_upload_url(token, 'update-blks-api')
         return Response(url)
 
-def get_dir_file_recursively(username, repo_id, path, all_dirs):
+def _collect_dir_file_recursively(username, repo_id, path, all_dirs):
     is_pro = is_pro_version()
     path_id = seafile_api.get_dir_id_by_path(repo_id, path)
     dirs = seafile_api.list_dir_with_perm(repo_id, path,
@@ -2313,25 +2313,31 @@ def get_dir_file_recursively(username, repo_id, path, all_dirs):
 
         all_dirs.append(entry)
 
-        # Use dict to reduce memcache fetch cost in large for-loop.
-        file_list =  [item for item in all_dirs if item['type'] == 'file']
-        contact_email_dict = {}
-        nickname_dict = {}
-        modifiers_set = {x['modifier_email'] for x in file_list}
-        for e in modifiers_set:
-            if e not in contact_email_dict:
-                contact_email_dict[e] = email2contact_email(e)
-            if e not in nickname_dict:
-                nickname_dict[e] = email2nickname(e)
-
-        for e in file_list:
-            e['modifier_contact_email'] = contact_email_dict.get(e['modifier_email'], '')
-            e['modifier_name'] = nickname_dict.get(e['modifier_email'], '')
-
-
         if stat.S_ISDIR(dirent.mode):
             sub_path = posixpath.join(path, dirent.obj_name)
-            get_dir_file_recursively(username, repo_id, sub_path, all_dirs)
+            _collect_dir_file_recursively(username, repo_id, sub_path, all_dirs)
+
+    return all_dirs
+
+
+def get_dir_file_recursively(username, repo_id, path, all_dirs):
+    _collect_dir_file_recursively(username, repo_id, path, all_dirs)
+
+    # Resolve modifier display names once, after the whole tree has been
+    # walked.
+    file_list = [item for item in all_dirs if item['type'] == 'file']
+    contact_email_dict = {}
+    nickname_dict = {}
+    modifiers_set = {x['modifier_email'] for x in file_list}
+    for e in modifiers_set:
+        if e not in contact_email_dict:
+            contact_email_dict[e] = email2contact_email(e)
+        if e not in nickname_dict:
+            nickname_dict[e] = email2nickname(e)
+
+    for e in file_list:
+        e['modifier_contact_email'] = contact_email_dict.get(e['modifier_email'], '')
+        e['modifier_name'] = nickname_dict.get(e['modifier_email'], '')
 
     return all_dirs
 

--- a/seahub/repo_api_tokens/utils.py
+++ b/seahub/repo_api_tokens/utils.py
@@ -37,7 +37,7 @@ def permission_check_admin_owner(request, username, repo_id):  # maybe add more 
         return is_group_repo_staff(request, repo_id, username)
 
 
-def get_dir_file_recursively(repo_id, path, all_dirs):
+def _collect_dir_file_recursively(repo_id, path, all_dirs):
     is_pro = is_pro_version()
     dirs = seafile_api.list_dir_by_path(repo_id, path, -1, -1)
 
@@ -64,24 +64,29 @@ def get_dir_file_recursively(repo_id, path, all_dirs):
 
         all_dirs.append(entry)
 
-        # Use dict to reduce memcache fetch cost in large for-loop.
-        file_list = [item for item in all_dirs if item['type'] == 'file']
-        contact_email_dict = {}
-        nickname_dict = {}
-        modifiers_set = {x['modifier_email'] for x in file_list}
-        for e in modifiers_set:
-            if e not in contact_email_dict:
-                contact_email_dict[e] = email2contact_email(e)
-            if e not in nickname_dict:
-                nickname_dict[e] = email2nickname(e)
-
-        for e in file_list:
-            e['modifier_contact_email'] = contact_email_dict.get(e['modifier_email'], '')
-            e['modifier_name'] = nickname_dict.get(e['modifier_email'], '')
-
         if stat.S_ISDIR(dirent.mode):
             sub_path = posixpath.join(path, dirent.obj_name)
-            get_dir_file_recursively(repo_id, sub_path, all_dirs)
+            _collect_dir_file_recursively(repo_id, sub_path, all_dirs)
+
+    return all_dirs
+
+
+def get_dir_file_recursively(repo_id, path, all_dirs):
+    _collect_dir_file_recursively(repo_id, path, all_dirs)
+
+    file_list = [item for item in all_dirs if item['type'] == 'file']
+    contact_email_dict = {}
+    nickname_dict = {}
+    modifiers_set = {x['modifier_email'] for x in file_list}
+    for e in modifiers_set:
+        if e not in contact_email_dict:
+            contact_email_dict[e] = email2contact_email(e)
+        if e not in nickname_dict:
+            nickname_dict[e] = email2nickname(e)
+
+    for e in file_list:
+        e['modifier_contact_email'] = contact_email_dict.get(e['modifier_email'], '')
+        e['modifier_name'] = nickname_dict.get(e['modifier_email'], '')
 
     return all_dirs
 


### PR DESCRIPTION
get_dir_file_recursively() resolved modifier display names inside the per-dirent loop, but all_dirs accumulates across the entire recursive walk -- so every dirent rescanned and rewrote every entry found so far, giving n(n+1)/2 operations. The memo dicts were also re-created on each iteration, so the memcache/db lookups they exist to avoid were re-issued on every pass. The concept of the memcache/db was excellent just needed to be fully implemented.

Here we move the block out of the walk and run it once at the end. Output is unchanged; the same values are computed once instead of n/2 times. The same optimization is applied in the copy in repo_api_tokens/utils.py.

Everywhere else in this codebase the block is already placed after the loop it feeds -- including elsewhere in these same two files. These two recursive copies were the only ones indented one level too deep.

Measured on a ~400,000-dirent library: did not complete in 900s before, 85.7s after. This is the endpoint rclone's seafile backend uses for its recursive listing, so it affects every rclone ls/sync on a large library.