### PR TITLE
fix: support sdoc links in wiki preview

### DIFF
--- a/frontend/src/pages/wiki2/main-panel.js
+++ b/frontend/src/pages/wiki2/main-panel.js
@@ -65,6 +65,7 @@ class MainPanel extends Component {
     };
     this.scrollRef = React.createRef();
     this.hashScrollTimer = null;
+    this.previewRequestId = 0;
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -109,6 +110,7 @@ class MainPanel extends Component {
   }
 
   componentWillUnmount() {
+    this.previewRequestId += 1;
     this.unsubscribeUnseenNotificationsCount();
     this.unsubscribeWikiFilePreview();
     this.unsubscribeGenerateExdrawReadOnlyLink();
@@ -147,36 +149,71 @@ class MainPanel extends Component {
   };
 
   toggleWikiFilePreview = (data) => {
+    const isWikiLink = data?.type === 'wiki_link';
+    const isSdocLink = data?.type === 'sdoc_link';
+
+    if (isWikiLink && (!data.wiki_repo_id || !data.page_id)) return;
+    if (isSdocLink && !data.doc_uuid) return;
+    if (!isWikiLink && !isSdocLink) return;
+
+    const requestId = ++this.previewRequestId;
+    const previewDocInfo = {
+      type: data.type,
+      title: data.title,
+      pageId: isWikiLink ? data.page_id : '',
+      config: isWikiLink ? this.props.config : null,
+    };
+
     this.setState({
       isPreviewFile: true,
       isReloadingPreview: true,
-      previewDocUuid: {},
+      previewDocUuid: '',
+      docContent: {},
+      previewDocInfo,
       isShowRightPanel: false
     });
 
-    // Firstly get access token config and then use it to get wiki content
-    const getWikiPage = wikiAPI.getWiki2Page(data.wiki_repo_id, data.page_id);
-    getWikiPage.then(res => {
-      const { seadoc_access_token, assets_url } = res.data;
-      const docUuid = assets_url.slice(assets_url.lastIndexOf('/') + 1);
-      const config = {
-        docUuid,
-        sdocServer: seadocServerUrl,
-        accessToken: seadoc_access_token,
-      };
-      this.setState({ previewDocUuid: docUuid });
-
-      const sdocServerApi = new SDocServerApi(config);
-      sdocServerApi.getDocContent().then(docRes => {
-        this.setState({
+    const getDocContent = isWikiLink
+      ? wikiAPI.getWiki2Page(data.wiki_repo_id, data.page_id).then(res => {
+        const { seadoc_access_token, assets_url } = res.data;
+        const docUuid = assets_url.slice(assets_url.lastIndexOf('/') + 1);
+        const config = {
+          docUuid,
+          sdocServer: seadocServerUrl,
+          accessToken: seadoc_access_token,
+        };
+        return new SDocServerApi(config).getDocContent().then(docRes => ({
           docContent: docRes.data,
-          isReloadingPreview: false,
-          previewDocInfo: { pageId: data.page_id, config: this.props.config }
-        });
+          docUuid,
+        }));
+      })
+      : seafileAPI.getSdocAccessTokenByUuid(data.doc_uuid).then(res => {
+        const config = {
+          docUuid: data.doc_uuid,
+          sdocServer: seadocServerUrl,
+          accessToken: res.data.access_token,
+        };
+        return new SDocServerApi(config).getDocContent().then(docRes => ({
+          docContent: docRes.data,
+          docUuid: data.doc_uuid,
+        }));
+      });
+
+    getDocContent.then(({ docContent, docUuid }) => {
+      if (requestId !== this.previewRequestId) return;
+      this.setState({
+        previewDocUuid: docUuid,
+        docContent,
+        isReloadingPreview: false,
       });
     }).catch(error => {
+      if (requestId !== this.previewRequestId) return;
       // eslint-disable-next-line no-console
       console.error(error);
+      this.setState({
+        docContent: {},
+        isReloadingPreview: false,
+      });
     });
   };
 
@@ -204,6 +241,7 @@ class MainPanel extends Component {
   }
 
   togglePreview = () => {
+    this.previewRequestId += 1;
     this.setState({ isPreviewFile: false });
   };
 

--- a/frontend/src/pages/wiki2/wiki-right-panel/wiki-preview/index.css
+++ b/frontend/src/pages/wiki2/wiki-right-panel/wiki-preview/index.css
@@ -44,6 +44,16 @@
   font-size: 14px;
 }
 
+.wiki-file-preview-drawer .wiki-file-preview-panel-header .wiki-file-preview-panel-header-left .sdoc-preview-title {
+  color: #212529;
+  font-size: 16px;
+  font-weight: 500;
+  max-width: 360px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .wiki-file-preview-drawer .wiki-file-preview-panel-header .wiki-file-preview-panel-header-left .wiki-detail-header-icon-container {
   align-items: center;
   display: flex;

--- a/frontend/src/pages/wiki2/wiki-right-panel/wiki-preview/index.js
+++ b/frontend/src/pages/wiki2/wiki-right-panel/wiki-preview/index.js
@@ -16,8 +16,27 @@ const FilePreviewWrapper = ({ docContent, previewDocUuid, setEditor, togglePrevi
   const scrollRef = useRef();
 
   const { config, pageId } = previewDocInfo;
+  const isSdocPreview = previewDocInfo.type === 'sdoc_link';
+  const hasPreviewContent = docContent?.elements && !isReloadingPreview && previewDocInfo.type;
   const wikiTopNavProps = { config, currentPageId: pageId };
   const currentPageConfig = config && pageId && getCurrentPageConfig(config.pages, pageId);
+
+  const previewContent = (
+    <>
+      {!isSdocPreview && <RightHeader currentPageConfig={ currentPageConfig && { ...currentPageConfig, locked: true }} />}
+      <SdocWikiEditor
+        document={docContent}
+        docUuid={previewDocUuid}
+        isWikiReadOnly={true}
+        scrollRef={scrollRef}
+        collaborators={[]}
+        showComment={false}
+        isShowRightPanel={false}
+        setEditor={setEditor}
+        mathJaxSource={mediaUrl + 'js/mathjax/tex-svg.js'}
+      />
+    </>
+  );
 
   const openFullscreen = (e) => {
     e.stopPropagation();
@@ -45,7 +64,11 @@ const FilePreviewWrapper = ({ docContent, previewDocUuid, setEditor, togglePrevi
           <div className="wiki-file-preview-panel-header">
             <div className="wiki-file-preview-panel-header-left">
               <div className="wiki-detail-header-icon-container">
-                {previewDocInfo.config && <WikiTopNav {...wikiTopNavProps} />}
+                {isSdocPreview ? (
+                  <span className='sdoc-preview-title' title={previewDocInfo.title}>{previewDocInfo.title}</span>
+                ) : (
+                  previewDocInfo.config && <WikiTopNav {...wikiTopNavProps} />
+                )}
               </div>
             </div>
             <div className="wiki-file-preview-panel-header-right">
@@ -68,22 +91,11 @@ const FilePreviewWrapper = ({ docContent, previewDocUuid, setEditor, togglePrevi
                 <FileLoading />
               </div>
             )}
-            {docContent?.elements && !isReloadingPreview && previewDocInfo.config && (
+            {hasPreviewContent && (
               <div className='wiki-file-preview-container' ref={wikiFilePreviewRef}>
                 <div className='wiki-scroll-container' ref={scrollRef}>
                   <div className='wiki-preview-container'>
-                    <RightHeader currentPageConfig={ currentPageConfig && { ...currentPageConfig, locked: true }} />
-                    <SdocWikiEditor
-                      document={docContent}
-                      docUuid={previewDocUuid}
-                      isWikiReadOnly={true}
-                      scrollRef={scrollRef}
-                      collaborators={[]}
-                      showComment={false}
-                      isShowRightPanel={false}
-                      setEditor={setEditor}
-                      mathJaxSource={mediaUrl + 'js/mathjax/tex-svg.js'}
-                    />
+                    {previewContent}
                   </div>
                 </div>
               </div>
@@ -91,7 +103,7 @@ const FilePreviewWrapper = ({ docContent, previewDocUuid, setEditor, togglePrevi
           </div>
         </div>
       </div>
-      {isShowZoomOut && docContent?.elements && previewDocInfo.config && (
+      {isShowZoomOut && hasPreviewContent && (
         ReactDOM.createPortal(
           <div className='wiki-zoom-out-container' onClick={() => setIsShowZoomOut(false)}>
             <div
@@ -101,18 +113,7 @@ const FilePreviewWrapper = ({ docContent, previewDocUuid, setEditor, togglePrevi
             >
               <div className='wiki-scroll-container' ref={scrollRef}>
                 <div className='wiki-preview-container'>
-                  <RightHeader currentPageConfig={ currentPageConfig && { ...currentPageConfig, locked: true }} />
-                  <SdocWikiEditor
-                    document={docContent}
-                    docUuid={previewDocUuid}
-                    isWikiReadOnly={true}
-                    scrollRef={scrollRef}
-                    collaborators={[]}
-                    showComment={false}
-                    isShowRightPanel={false}
-                    setEditor={setEditor}
-                    mathJaxSource={mediaUrl + 'js/mathjax/tex-svg.js'}
-                  />
+                  {previewContent}
                 </div>
               </div>
             </div>

--- a/frontend/src/pages/wiki2/wiki-right-panel/wiki-preview/index.js
+++ b/frontend/src/pages/wiki2/wiki-right-panel/wiki-preview/index.js
@@ -1,42 +1,26 @@
 import React, { useRef, useState, useEffect } from 'react';
 import ReactDOM from 'react-dom';
-import { SdocWikiEditor } from '@seafile/seafile-sdoc-editor';
 import FileLoading from '../file-loading';
 import WikiTopNav from '../../top-nav';
 import { getCurrentPageConfig } from '../../utils';
-import RightHeader from '../../wiki-right-header';
 import Icon from '../../../../components/icon';
-import { mediaUrl } from '../../../../utils/constants';
+
+import PreviewContent from './preview-content';
 
 import './index.css';
 
 const FilePreviewWrapper = ({ docContent, previewDocUuid, setEditor, togglePreview, isReloadingPreview, previewDocInfo }) => {
   const [isShowZoomOut, setIsShowZoomOut] = useState(false);
   const wikiFilePreviewRef = useRef();
+  const zoomOutPreviewRef = useRef();
   const scrollRef = useRef();
+  const zoomOutScrollRef = useRef();
 
   const { config, pageId } = previewDocInfo;
   const isSdocPreview = previewDocInfo.type === 'sdoc_link';
-  const hasPreviewContent = docContent?.elements && !isReloadingPreview && previewDocInfo.type;
+  const hasPreviewContent = Boolean(docContent?.elements && !isReloadingPreview && previewDocInfo.type);
   const wikiTopNavProps = { config, currentPageId: pageId };
   const currentPageConfig = config && pageId && getCurrentPageConfig(config.pages, pageId);
-
-  const previewContent = (
-    <>
-      {!isSdocPreview && <RightHeader currentPageConfig={ currentPageConfig && { ...currentPageConfig, locked: true }} />}
-      <SdocWikiEditor
-        document={docContent}
-        docUuid={previewDocUuid}
-        isWikiReadOnly={true}
-        scrollRef={scrollRef}
-        collaborators={[]}
-        showComment={false}
-        isShowRightPanel={false}
-        setEditor={setEditor}
-        mathJaxSource={mediaUrl + 'js/mathjax/tex-svg.js'}
-      />
-    </>
-  );
 
   const openFullscreen = (e) => {
     e.stopPropagation();
@@ -95,7 +79,14 @@ const FilePreviewWrapper = ({ docContent, previewDocUuid, setEditor, togglePrevi
               <div className='wiki-file-preview-container' ref={wikiFilePreviewRef}>
                 <div className='wiki-scroll-container' ref={scrollRef}>
                   <div className='wiki-preview-container'>
-                    {previewContent}
+                    <PreviewContent
+                      docContent={docContent}
+                      previewDocUuid={previewDocUuid}
+                      setEditor={setEditor}
+                      scrollRef={scrollRef}
+                      isSdocPreview={isSdocPreview}
+                      currentPageConfig={currentPageConfig}
+                    />
                   </div>
                 </div>
               </div>
@@ -108,12 +99,19 @@ const FilePreviewWrapper = ({ docContent, previewDocUuid, setEditor, togglePrevi
           <div className='wiki-zoom-out-container' onClick={() => setIsShowZoomOut(false)}>
             <div
               className='file-preview-zoom-out-container'
-              ref={wikiFilePreviewRef}
+              ref={zoomOutPreviewRef}
               onClick={(e) => e.stopPropagation()}
             >
-              <div className='wiki-scroll-container' ref={scrollRef}>
+              <div className='wiki-scroll-container' ref={zoomOutScrollRef}>
                 <div className='wiki-preview-container'>
-                  {previewContent}
+                  <PreviewContent
+                    docContent={docContent}
+                    previewDocUuid={previewDocUuid}
+                    setEditor={setEditor}
+                    scrollRef={zoomOutScrollRef}
+                    isSdocPreview={isSdocPreview}
+                    currentPageConfig={currentPageConfig}
+                  />
                 </div>
               </div>
             </div>

--- a/frontend/src/pages/wiki2/wiki-right-panel/wiki-preview/preview-content.js
+++ b/frontend/src/pages/wiki2/wiki-right-panel/wiki-preview/preview-content.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { SdocWikiEditor } from '@seafile/seafile-sdoc-editor';
+import RightHeader from '../../wiki-right-header';
+import { mediaUrl } from '../../../../utils/constants';
+
+const PreviewContent = ({
+  docContent,
+  previewDocUuid,
+  setEditor,
+  scrollRef,
+  isSdocPreview,
+  currentPageConfig,
+}) => (
+  <>
+    {!isSdocPreview && (
+      <RightHeader
+        currentPageConfig={currentPageConfig && { ...currentPageConfig, locked: true }}
+      />
+    )}
+    <SdocWikiEditor
+      document={docContent}
+      docUuid={previewDocUuid}
+      isWikiReadOnly={true}
+      scrollRef={scrollRef}
+      collaborators={[]}
+      showComment={false}
+      isShowRightPanel={false}
+      setEditor={setEditor}
+      mathJaxSource={mediaUrl + 'js/mathjax/tex-svg.js'}
+    />
+  </>
+);
+
+export default PreviewContent;

--- a/frontend/src/utils/seafile-api.js
+++ b/frontend/src/utils/seafile-api.js
@@ -1490,6 +1490,11 @@ class SeafileAPI {
   }
 
 
+  getSdocAccessTokenByUuid(docUuid) {
+    const url = this.server + '/api/v2.1/seadoc/access-token-by-uuid/' + docUuid + '/';
+    return this.req.get(url);
+  }
+
   listSdocNotifications(page, perPage) {
     const url = this.server + '/api/v2.1/sdoc-notifications/';
     let params = {


### PR DESCRIPTION
## Summary
- support previewing sdoc_link in the Wiki right panel
- reuse SdocWikiEditor for both wiki_link and sdoc_link
- fetch sdoc access tokens by document UUID
- guard against stale preview requests

## Testing
- NODE_ENV=development ./node_modules/.bin/eslint src/pages/wiki2/main-panel.js src/pages/wiki2/wiki-right-panel/wiki-preview/index.js src/utils/seafile-api.js
- git diff --check
- Jest was blocked because jest-environment-jsdom is not installed
- Production build was started but stopped after prolonged no-output; generated stats file was restored