### PR TITLE
fix(wiki): remove settings entry from wiki2 navigation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@seafile/resumablejs": "1.1.16",
         "@seafile/seafile-calendar": "1.0.13",
         "@seafile/seafile-editor": "3.0.45",
-        "@seafile/seafile-sdoc-editor": "3.0.230",
+        "@seafile/seafile-sdoc-editor": "3.0.232",
         "@seafile/stldraw-editor": "1.0.1",
         "@uiw/codemirror-extensions-langs": "^4.19.4",
         "@uiw/codemirror-themes": "^4.23.5",
@@ -7409,9 +7409,9 @@
       "license": "MIT"
     },
     "node_modules/@seafile/sdoc-editor": {
-      "version": "3.0.230",
-      "resolved": "https://registry.npmjs.org/@seafile/sdoc-editor/-/sdoc-editor-3.0.230.tgz",
-      "integrity": "sha512-FzHiJ0P9wQxSxF3CaZOJu8MvaUCJ9MDsdh0s3ybsLaDWAOywULnp3zL5j1CjlyVJvpqVSZi2P7et7ArcWHeRmw==",
+      "version": "3.0.232",
+      "resolved": "https://registry.npmjs.org/@seafile/sdoc-editor/-/sdoc-editor-3.0.232.tgz",
+      "integrity": "sha512-69pPGahv9/3uHK1zhFqQHp8Bp9JKtlrc1BRySZ5lLxz6JzYOq6IEUETbBwQvZRxBzU4sx7XpVEF30mamGvWMXg==",
       "license": "ISC",
       "dependencies": {
         "@seafile/comment-editor": "1.0.31",
@@ -7667,13 +7667,13 @@
       }
     },
     "node_modules/@seafile/seafile-sdoc-editor": {
-      "version": "3.0.230",
-      "resolved": "https://registry.npmjs.org/@seafile/seafile-sdoc-editor/-/seafile-sdoc-editor-3.0.230.tgz",
-      "integrity": "sha512-kvXIWjT9gB6xXdw8CvkRIyqFxn1qC7yBd7aQ+A+iLx8jyNzzGoIpB0RdJ7WLpWphaXZyF9HxYTbzjbJ3l3doVg==",
+      "version": "3.0.232",
+      "resolved": "https://registry.npmjs.org/@seafile/seafile-sdoc-editor/-/seafile-sdoc-editor-3.0.232.tgz",
+      "integrity": "sha512-ZYxvb2Bt2OS+tW2QpKqk9K8/0PG2tWvNavAvQJEUDYQUtYydUx5L4Gsxbr5s7HSIQT6ZFogQYNpg569nlLMjNw==",
       "license": "ISC",
       "dependencies": {
         "@seafile/print-js": "1.6.6",
-        "@seafile/sdoc-editor": "^3.0.230",
+        "@seafile/sdoc-editor": "^3.0.232",
         "classnames": "2.3.2",
         "dayjs": "1.10.7"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@seafile/resumablejs": "1.1.16",
     "@seafile/seafile-calendar": "1.0.13",
     "@seafile/seafile-editor": "3.0.45",
-    "@seafile/seafile-sdoc-editor": "3.0.230",
+    "@seafile/seafile-sdoc-editor": "3.0.232",
     "@seafile/stldraw-editor": "1.0.1",
     "@uiw/codemirror-extensions-langs": "^4.19.4",
     "@uiw/codemirror-themes": "^4.23.5",

--- a/frontend/src/pages/wiki2/wiki-nav/wiki-nav.js
+++ b/frontend/src/pages/wiki2/wiki-nav/wiki-nav.js
@@ -5,7 +5,7 @@ import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import PageItem from './pages/page-item';
 import PageDragLayer from './pages/page-drag-layer';
-import { gettext, wikiPermission, enableMetadataManagement } from '../../../utils/constants';
+import { gettext, wikiPermission } from '../../../utils/constants';
 import { Utils } from '../../../utils/utils';
 import toaster from '../../../components/toast';
 import Icon from '../../../components/icon';
@@ -216,12 +216,6 @@ class WikiNav extends Component {
             <div className="wiki-nav-group-header px-2">
               <h2 className="h6 font-weight-normal m-0">{gettext('Other')}</h2>
             </div>
-            {enableMetadataManagement && (
-              <div role='button' tabIndex={0} className={classNames('other-op wiki2-set-up', { 'mt-0': !pagesLen })} onClick={this.props.toggleSettingDialog}>
-                <span className="d-flex align-items-center mr-2"><Icon symbol="set-up" /></span>
-                <span className="other-op-label">{gettext('Settings')}</span>
-              </div>
-            )}
             <div role='button' tabIndex={1} className={classNames('other-op wiki2-trash', { 'mt-0': !pagesLen })} onClick={this.props.toggleTrashDialog}>
               <span className="d-flex align-items-center mr-2"><Icon symbol="trash" /></span>
               <span className="other-op-label">{gettext('Trash')}</span>


### PR DESCRIPTION
## Summary
- remove the Settings entry from the wiki2 navigation
- keep the existing settings dialog and other access paths intact

## Testing
- `git diff --check`
- `NODE_ENV=development ./frontend/node_modules/.bin/eslint frontend/src/pages/wiki2/wiki-nav/wiki-nav.js`