### PR TITLE
fix: adjust dropdown icon spacing

### DIFF
--- a/frontend/src/pages/wiki2/wiki-nav/pages/page-dropdownmenu.js
+++ b/frontend/src/pages/wiki2/wiki-nav/pages/page-dropdownmenu.js
@@ -153,7 +153,7 @@ export default class PageDropdownMenu extends Component {
       ...(canDeletePage ? [{
         key: 'delete-page',
         label: gettext('Delete page'),
-        icon_dom: <Icon symbol="delete1" aria-hidden="true" />,
+        icon_dom: <Icon symbol="delete" aria-hidden="true" />,
         onClick: this.onDeletePage,
       }] : []),
       {

--- a/frontend/src/pages/wiki2/wiki-nav/wiki-nav.js
+++ b/frontend/src/pages/wiki2/wiki-nav/wiki-nav.js
@@ -169,7 +169,7 @@ class WikiNav extends Component {
     const pageOperationItems = [{
       key: 'import-page',
       label: gettext('Import page'),
-      icon_dom: <Icon symbol="import-sdoc" className="mr-2" aria-hidden="true" />,
+      icon_dom: <Icon symbol="import-sdoc" aria-hidden="true" />,
       children: [
         { key: 'import-docx', label: gettext('Import page from docx'), onClick: () => this.handleImportPage('.docx') },
         { key: 'import-md', label: gettext('Import page from Markdown'), onClick: () => this.handleImportPage('.md') },

--- a/frontend/src/tag/components/tag-view-name/all-tags-operation-toolbar.js
+++ b/frontend/src/tag/components/tag-view-name/all-tags-operation-toolbar.js
@@ -70,19 +70,19 @@ const AllTagsOperationToolbar = ({ repoID }) => {
     {
       key: 'new-tag',
       label: gettext('New tag'),
-      icon_dom: <Icon symbol="new" className="mr-1 dropdown-item-icon" />,
+      icon_dom: <Icon symbol="new" className="dropdown-item-icon" />,
       onClick: openAddTag,
     },
     {
       key: 'import-tags',
       label: gettext('Import tags'),
-      icon_dom: <Icon symbol="import-sdoc" className="mr-1 dropdown-item-icon" />,
+      icon_dom: <Icon symbol="import-sdoc" className="dropdown-item-icon" />,
       onClick: handleImportTags,
     },
     {
       key: 'export-tags',
       label: gettext('Export tags'),
-      icon_dom: <Icon symbol="download" className="mr-1 dropdown-item-icon" />,
+      icon_dom: <Icon symbol="download" className="dropdown-item-icon" />,
       onClick: handleExportTags,
     }
   ]), [openAddTag, handleImportTags, handleExportTags]);


### PR DESCRIPTION
## Summary
- adjust wiki page operation icon spacing
- align tag operation toolbar icon spacing

## Testing
- NODE_ENV=development ./node_modules/.bin/eslint src/pages/wiki2/wiki-nav/pages/page-dropdownmenu.js src/pages/wiki2/wiki-nav/wiki-nav.js src/tag/components/tag-view-name/all-tags-operation-toolbar.js
- git diff --check