### PR TITLE
fix: reset user select search state

### DIFF
--- a/frontend/src/components/user-select.js
+++ b/frontend/src/components/user-select.js
@@ -170,7 +170,12 @@ class UserSelect extends React.Component {
   onEsc = (e) => {
     e.preventDefault();
     e.stopPropagation();
-    this.setState({ isPopoverOpen: false });
+    this.setState({
+      isPopoverOpen: false,
+      searchedUsers: [],
+      searchValue: '',
+      highlightIndex: -1
+    });
   };
 
   onUserClick = (user) => {
@@ -206,10 +211,12 @@ class UserSelect extends React.Component {
   };
 
   onTogglePopover = () => {
-    this.setState({ isPopoverOpen: !this.state.isPopoverOpen });
-    if (!this.state.isPopoverOpen) {
-      this.onValueChanged(this.state.searchValue);
-    }
+    this.setState({
+      isPopoverOpen: !this.state.isPopoverOpen,
+      highlightIndex: -1,
+      searchedUsers: [],
+      searchValue: ''
+    });
   };
 
   render() {
@@ -265,6 +272,7 @@ class UserSelect extends React.Component {
                   onChange={this.onValueChanged}
                   onKeyDown={this.onKeyDown}
                   isClearable={true}
+                  clearValue={() => this.onValueChanged('')}
                 />
               </div>
               <div className="user-list-container" ref={ref => this.container = ref}>


### PR DESCRIPTION
## Summary
- reset search results, query, and highlight state when closing or reopening the user selector
- clear the search input through the SearchInput clear action

## Testing
- NODE_ENV=development ./node_modules/.bin/eslint src/components/user-select.js
- CI=true npm test -- --watchAll=false --runInBand (blocked: missing jest-environment-jsdom)