### PR TITLE
Fix 2FA enrolment locking out users who run setup twice

### DIFF
--- a/seahub/two_factor/forms.py
+++ b/seahub/two_factor/forms.py
@@ -102,10 +102,17 @@ class TOTPDeviceForm(forms.Form):
         return token
 
     def save(self):
-        return TOTPDevice.objects.create(user=self.user.username, key=self.key,
-                                         tolerance=self.tolerance, t0=self.t0,
-                                         step=self.step, drift=self.drift,
-                                         digits=self.digits)
+        # `two_factor_totpdevice.user` is unique, so creating unconditionally
+        # raises IntegrityError when the user already has a device -- discarding
+        # the secret they have just scanned while their app keeps it. clean_token()
+        # has already validated the submitted token against the new key, so
+        # possession is proven before the old device is replaced.
+        device, _ = TOTPDevice.objects.update_or_create(
+            user=self.user.username,
+            defaults=dict(key=self.key, tolerance=self.tolerance, t0=self.t0,
+                          step=self.step, drift=self.drift,
+                          digits=self.digits))
+        return device
 
 
 class DisableForm(forms.Form):


### PR DESCRIPTION
### Problem

`TOTPDeviceForm.save()` calls `TOTPDevice.objects.create()`, but
`two_factor_totpdevice.user` carries a unique constraint. If a user runs the
two-factor setup wizard while a device already exists on their account, the
final step raises `IntegrityError` and returns HTTP 500:

```
File ".../seahub/two_factor/views/utils.py", line 181, in render_done
File ".../seahub/two_factor/views/core.py", line 124, in done
File ".../seahub/two_factor/forms.py", line 105, in save
    return TOTPDevice.objects.create(user=self.user.username, key=self.key,
MySQLdb.IntegrityError: (1062, "Duplicate entry '<user>@auth.local' for key 'user'")
```

The consequence is worse than the 500. The secret the user has just scanned is
discarded, but their authenticator app keeps it — so the server goes on
validating against the **old** secret while the user can only generate codes for
the **new** one. Every subsequent login is rejected:

```
verify_token user input invalid token = 753674, totp.token = 673516
```

Both are well-formed six-digit codes; they derive from different secrets. (Clock
skew was ruled out — host and container NTP-synced, and `totp.t` advances
normally across the failures.)

There is no self-service recovery. A password reset does not clear 2FA, so an
administrator has to delete rows from `two_factor_totpdevice` and
`two_factor_staticdevice` directly. On a deployment using
`ENABLE_FORCE_2FA_TO_ALL_USERS` or per-user `force_2fa`, the account is locked
out entirely.

### Steps to reproduce

1. As a normal user, enable two-factor authentication and complete enrolment.
2. Without disabling it, open `/profile/two_factor_authentication/setup/` again.
3. Scan the new QR code and submit a valid code generated from it.

### Fix

Use `update_or_create()` so re-enrolment replaces the existing device.

This is safe because `clean_token()`, in the same form, has already validated
the submitted token **against the new key** before `save()` runs — possession of
the new secret is proven before the old device is replaced. The current code
performs exactly that validation and then throws the result away.

### Verification

Both paths exercised against the live model on 13.0.25:

```
--- control: the OLD code path (create) ---
  first create  : ok, key=aaaaaa
  second create : IntegrityError (1062, "Duplicate entry ...")
--- patched code path (update_or_create) ---
  re-enrol      : ok, key=cccccc
  device rows   : 1 (expect 1)
```

Found on a ~190-user deployment, where a user simply ran the wizard twice.
