### PR TITLE
rename get_dir_file_recursively to get_dir_file_recursively_with_perm

### DIFF
--- a/seahub/api2/endpoints/dir.py
+++ b/seahub/api2/endpoints/dir.py
@@ -15,7 +15,7 @@ from urllib.parse import quote
 from seahub.api2.throttling import UserRateThrottle
 from seahub.api2.authentication import TokenAuthentication
 from seahub.api2.utils import api_error, to_python_boolean
-from seahub.api2.views import get_dir_file_recursively
+from seahub.api2.views import get_dir_file_recursively_with_perm
 
 from seahub.thumbnail.utils import generate_thumbnail_key, get_thumbnail_src
 from seahub.views import check_folder_permission
@@ -282,7 +282,7 @@ class DirView(APIView):
         if recursive == '1':
 
             try:
-                dir_file_info_list = get_dir_file_recursively(username, repo_id,
+                dir_file_info_list = get_dir_file_recursively_with_perm(username, repo_id,
                         parent_dir, [])
             except Exception as e:
                 logger.error(e)

--- a/seahub/api2/endpoints/repo_commit_dir.py
+++ b/seahub/api2/endpoints/repo_commit_dir.py
@@ -27,7 +27,6 @@ class RepoCommitDirView(APIView):
 
     def _get_item_info(self, dirent, path):
 
-        # # seahub/seahub/api2/views get_dir_file_recursively
         entry = {}
         if stat.S_ISDIR(dirent.mode):
             entry['type'] = 'dir'

--- a/seahub/api2/endpoints/wiki_pages.py
+++ b/seahub/api2/endpoints/wiki_pages.py
@@ -17,7 +17,6 @@ from django.utils.translation import gettext as _
 
 from seahub.views import check_folder_permission
 from seahub.views.file import send_file_access_msg
-from seahub.api2.views import get_dir_file_recursively
 from seahub.api2.authentication import TokenAuthentication
 from seahub.api2.throttling import UserRateThrottle
 from seahub.api2.utils import api_error, to_python_boolean

--- a/seahub/api2/views.py
+++ b/seahub/api2/views.py
@@ -2266,7 +2266,7 @@ class UpdateBlksLinkView(APIView):
         url = gen_file_upload_url(token, 'update-blks-api')
         return Response(url)
 
-def get_dir_file_recursively(username, repo_id, path, all_dirs):
+def get_dir_file_recursively_with_perm(username, repo_id, path, all_dirs):
     is_pro = is_pro_version()
     path_id = seafile_api.get_dir_id_by_path(repo_id, path)
     dirs = seafile_api.list_dir_with_perm(repo_id, path,
@@ -2322,7 +2322,7 @@ def get_dir_file_recursively(username, repo_id, path, all_dirs):
 
         if stat.S_ISDIR(dirent.mode):
             sub_path = posixpath.join(path, dirent.obj_name)
-            get_dir_file_recursively(username, repo_id, sub_path, all_dirs)
+            get_dir_file_recursively_with_perm(username, repo_id, sub_path, all_dirs)
 
     return all_dirs
 
@@ -3885,7 +3885,7 @@ class DirView(APIView):
         if recursive == '1':
             result = []
             username = request.user.username
-            dir_file_list = get_dir_file_recursively(username, repo_id, path, [])
+            dir_file_list = get_dir_file_recursively_with_perm(username, repo_id, path, [])
             if request_type == 'f':
                 for item in dir_file_list:
                     if item['type'] == 'file':


### PR DESCRIPTION
Rename in seahub/api2/views.py to disambiguate from the repo_api_tokens.utils version, and update its importers. Remove the now-unused import in wiki_pages.py and a stale comment.