### PR TITLE
fix: adjust library decrypt dialog close icon

### DIFF
--- a/frontend/src/components/dialog/lib-decrypt-dialog.js
+++ b/frontend/src/components/dialog/lib-decrypt-dialog.js
@@ -57,7 +57,7 @@ class LibDecryptDialog extends React.Component {
     return (
       <Modal isOpen={true} toggle={this.toggle}>
         <ModalBody>
-          <SeahubModalCloseIcon className="position-absolute top-0 end-0 m-0" toggle={this.toggle} />
+          <SeahubModalCloseIcon className="float-end" toggle={this.toggle} />
           <Form className="lib-decrypt-form text-center">
             <img src={`${mediaUrl}img/lock.png`} alt="" aria-hidden="true" />
             <p className="intro">{gettext('This library is password protected')}</p>


### PR DESCRIPTION
## Summary
- adjust the library decrypt dialog close icon layout class

## Testing
- NODE_ENV=development eslint src/components/dialog/lib-decrypt-dialog.js
- git diff --check