### PR TITLE
fix: deduplicate global search history

### DIFF
--- a/frontend/src/components/search/search.js
+++ b/frontend/src/components/search/search.js
@@ -512,12 +512,12 @@ class Search extends Component {
    */
   keepVisitedItem = (targetItem, savedRepoID) => {
     let targetIndex;
-    const { path: targetPath } = targetItem;
+    const { repo_id: targetRepoID, path: targetPath } = targetItem;
     const storeKey = 'sfVisitedSearchItems' + savedRepoID;
     const items = JSON.parse(localStorage.getItem(storeKey)) || [];
     for (let i = 0, len = items.length; i < len; i++) {
       const { repo_id, path } = items[i];
-      if (repo_id == savedRepoID && path == targetPath) {
+      if (repo_id == targetRepoID && path == targetPath) {
         targetIndex = i;
         break;
       }

--- a/frontend/src/components/search/search.js
+++ b/frontend/src/components/search/search.js
@@ -511,20 +511,11 @@ class Search extends Component {
    * @param {string} savedRepoID - The saved repo ID. If empty string, save in global localStorage.
    */
   keepVisitedItem = (targetItem, savedRepoID) => {
-    let targetIndex;
     const { repo_id: targetRepoID, path: targetPath } = targetItem;
     const storeKey = 'sfVisitedSearchItems' + savedRepoID;
-    const items = JSON.parse(localStorage.getItem(storeKey)) || [];
-    for (let i = 0, len = items.length; i < len; i++) {
-      const { repo_id, path } = items[i];
-      if (repo_id == targetRepoID && path == targetPath) {
-        targetIndex = i;
-        break;
-      }
-    }
-    if (targetIndex != undefined) {
-      items.splice(targetIndex, 1);
-    }
+    const items = (JSON.parse(localStorage.getItem(storeKey)) || []).filter(({ repo_id, path }) => {
+      return repo_id !== targetRepoID || path !== targetPath;
+    });
     items.unshift(targetItem);
     if (items.length > 50) { // keep 50 items at most
       items.pop();

--- a/frontend/src/components/search/search.test.js
+++ b/frontend/src/components/search/search.test.js
@@ -1,0 +1,26 @@
+import Search from './search';
+
+describe('Search visited results', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('removes all existing duplicates before adding the visited item', () => {
+    const targetItem = { repo_id: 'repo-1', path: '/document.md', name: 'document.md' };
+    const otherItem = { repo_id: 'repo-2', path: '/document.md', name: 'document.md' };
+    localStorage.setItem('sfVisitedSearchItems', JSON.stringify([
+      targetItem,
+      otherItem,
+      { ...targetItem, name: 'outdated-document.md' },
+      targetItem,
+    ]));
+    const search = new Search({ onSearchedClick: jest.fn() });
+
+    search.keepVisitedItem(targetItem, '');
+
+    expect(JSON.parse(localStorage.getItem('sfVisitedSearchItems'))).toEqual([
+      targetItem,
+      otherItem,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- deduplicate visited search results using the selected item repository ID and path
- prevent repeated clicks from adding duplicate entries to global search history

## Testing
- `NODE_ENV=development ./node_modules/.bin/eslint src/components/search/search.js`