### PR TITLE
fix: hide chat message content overflow

### DIFF
--- a/frontend/src/components/dir-view-mode/dir-chat/chat-history/common-message/index.css
+++ b/frontend/src/components/dir-view-mode/dir-chat/chat-history/common-message/index.css
@@ -2,7 +2,7 @@
   cursor: pointer;
 }
 
-.sea-ai-ask-chat.user-input-chat > .sea-ai-chat-message-attachments {
+.sea-ai-ask-chat.user-input-chat>.sea-ai-chat-message-attachments {
   max-width: 100%;
   flex-wrap: wrap !important;
   justify-content: flex-end !important;
@@ -15,7 +15,7 @@
 }
 
 .sea-ai-ask-message-content .sf-slate-viewer-scroll-container .sf-slate-article-content {
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 .sea-ai-ask-message-content .article {


### PR DESCRIPTION
## Summary
- hide overflow in chat history message content
- normalize the chat attachment selector formatting

## Testing
- git diff --check