### PR TITLE
[library settings] make the 'hide properties' popover scrollable afte…

### DIFF
--- a/frontend/src/metadata/components/dialog/metadata-status-manage-dialog/index.js
+++ b/frontend/src/metadata/components/dialog/metadata-status-manage-dialog/index.js
@@ -200,6 +200,7 @@ const MetadataStatusManagementDialog = ({ value: oldValue, repoID, hiddenColumns
             </Button>
             {isHiddenColumnsVisible && (
               <HideColumnPopover
+                maxHeight={300}
                 placement="bottom-end"
                 target="metadata-status-hide-properties-button"
                 hiddenColumns={hiddenColumns}

--- a/frontend/src/metadata/components/popover/hidden-column-popover/index.js
+++ b/frontend/src/metadata/components/popover/hidden-column-popover/index.js
@@ -11,7 +11,7 @@ import HiddenColumns from './hidden-columns';
 
 import './index.css';
 
-const HideColumnPopover = ({ hidePopover, onChange, readOnly, target, placement, columns, hiddenColumns: oldHiddenColumns, modifyColumnOrder }) => {
+const HideColumnPopover = ({ hidePopover, onChange, readOnly, target, placement, columns, hiddenColumns: oldHiddenColumns, modifyColumnOrder, maxHeight }) => {
   const [searchValue, setSearchValue] = useState('');
   const [hiddenColumns, setHiddenColumns] = useState(oldHiddenColumns);
   const displayColumns = useMemo(() => {
@@ -105,7 +105,7 @@ const HideColumnPopover = ({ hidePopover, onChange, readOnly, target, placement,
       className="sf-metadata-hide-columns-popover"
       boundariesElement={document.body}
     >
-      <div ref={popoverRef} onClick={onPopoverInsideClick} className="sf-metadata-hide-columns-container" style={{ maxHeight: window.innerHeight - 150 }}>
+      <div ref={popoverRef} onClick={onPopoverInsideClick} className="sf-metadata-hide-columns-container" style={{ maxHeight: maxHeight || window.innerHeight - 150 }}>
         <div className="sf-metadata-hide-columns-search-container">
           <SearchInput
             placeholder={gettext('Search property')}
@@ -150,6 +150,7 @@ const HideColumnPopover = ({ hidePopover, onChange, readOnly, target, placement,
 
 HideColumnPopover.propTypes = {
   readOnly: PropTypes.bool,
+  maxHeight: PropTypes.number,
   placement: PropTypes.string.isRequired,
   target: PropTypes.string.isRequired,
   hiddenColumns: PropTypes.array.isRequired,


### PR DESCRIPTION
…r the page was split into 2 tabs