### PR TITLE
refactor(popover): colocate tag item component

### DIFF
--- a/frontend/src/components/popover/edit-filetag-popover/index.js
+++ b/frontend/src/components/popover/edit-filetag-popover/index.js
@@ -8,7 +8,7 @@ import CommonAddTool from '../../common-add-tool';
 import CustomizePopover from '../../customize-popover';
 import SearchInput from '../../search-input';
 import toaster from '../../toast';
-import TagItem from '../tag-item';
+import TagItem from './tag-item';
 
 import './index.css';
 

--- a/frontend/src/components/popover/edit-filetag-popover/tag-item.js
+++ b/frontend/src/components/popover/edit-filetag-popover/tag-item.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { seafileAPI } from '../../utils/seafile-api';
-import { Utils } from '../../utils/utils';
-import Icon from '../icon';
-import toaster from '../toast';
+import { seafileAPI } from '../../../utils/seafile-api';
+import { Utils } from '../../../utils/utils';
+import Icon from '../../icon';
+import toaster from '../../toast';
 
 class TagItem extends React.Component {
 


### PR DESCRIPTION
## Summary
- move TagItem next to its only consumer, edit-filetag-popover
- update the local import path

## Testing
- NODE_ENV=development ./node_modules/.bin/eslint src/components/popover/edit-filetag-popover src/components/dirent-detail/dirent-details/file-details/file-tag.js
- git diff --check
- verified the old path is removed and the new import resolves