### PR TITLE
refactor: split plain markdown editor entry

### DIFF
--- a/frontend/config/webpack.entry.js
+++ b/frontend/config/webpack.entry.js
@@ -10,7 +10,7 @@ const entryFiles = {
   institutionAdmin: '/institution-admin.js',
   markdownEditor: '/markdown-editor.js',
   orgAdmin: '/org-admin.js',
-  plainMarkdownEditor: '/pages/plain-markdown-editor/index.js',
+  plainMarkdownEditor: '/plain-markdown-editor.js',
   repoFolderTrash: '/repo-folder-trash.js',
   repoHistory: '/repo-history.js',
   repoSnapshot: '/repo-snapshot.js',

--- a/frontend/src/pages/plain-markdown-editor/index.js
+++ b/frontend/src/pages/plain-markdown-editor/index.js
@@ -2,7 +2,6 @@ import React, { useState, useRef, useCallback, useLayoutEffect, useEffect } from
 import { processorWithMath } from '@seafile/seafile-editor';
 import isHotkey from 'is-hotkey';
 import PropTypes from 'prop-types';
-import { createRoot } from 'react-dom/client';
 import CodeMirrorLoading from '../../components/code-mirror-loading';
 import toaster from '../../components/toast';
 import { gettext } from '../../utils/constants';
@@ -261,6 +260,3 @@ const PlainMarkdownEditor = (props) => {
 PlainMarkdownEditor.propTypes = propTypes;
 
 export default PlainMarkdownEditor;
-
-const root = createRoot(document.getElementById('root'));
-root.render(<PlainMarkdownEditor />);

--- a/frontend/src/plain-markdown-editor.js
+++ b/frontend/src/plain-markdown-editor.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import PlainMarkdownEditor from './pages/plain-markdown-editor';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<PlainMarkdownEditor />);


### PR DESCRIPTION
## Summary
- move the plain markdown editor mount into a dedicated src entry file
- keep the page component and business logic under pages/plain-markdown-editor
- update the webpack entry path

## Testing
- NODE_ENV=development ./node_modules/.bin/eslint src/plain-markdown-editor.js src/pages/plain-markdown-editor/index.js
- git diff --check
- verified the webpack entry resolves to src/plain-markdown-editor.js